### PR TITLE
feat(v0.2.0): Application Layer — serialization + JSON export

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -112,13 +112,13 @@ component_management:
     # CSV : Export des résultats au format CSV
     # Décommenter quand le module sera implémenté
     # --------------------------------------------------------------------------
-    # - component_id: csv
-    #   name: "CSV Export"
-    #   paths:
-    #     - src/output/csv/**
-    #   statuses:
-    #     - type: project
-    #       target: 75% # Cible plus souple pour le csv
+    - component_id: csv
+      name: "CSV Export"
+      paths:
+        - src/output/csv/**
+      statuses:
+        - type: project
+          target: 75%
 
 # ============================================================================
 # FICHIERS IGNORÉS
@@ -128,6 +128,7 @@ ignore:
   - tests/
   - examples/
   - benches/
+  - tools/
   - "**/*_test.rs"
 
 # ============================================================================

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -2,9 +2,9 @@ name: Mirror to GitLab
 
 on:
   push:
-    branches: ['**']   # toutes les branches
-    tags: ['**']       # tous les tags (inclut les releases)
-  delete:              # synchronise aussi les suppressions de branches/tags
+    branches: ['**']   # all branches
+    tags: ['**']       # all tags (includes releases)
+  delete:              # also synchronise branch/tag deletions
 
 jobs:
   mirror:
@@ -13,18 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0   # historique complet obligatoire
+          fetch-depth: 0   # full history required
 
       - name: Push mirror to GitLab
         run: |
           git remote add gitlab \
             https://oauth2:${GITLAB_TOKEN}@gitlab.com/open-works/chromatography.git
 
-          # --mirror pousse aussi refs/remotes/* que GitLab refuse.
-          # On pousse uniquement les branches et les tags explicitement.
+          # Push branches without force — GitLab forbids force-push on the
+          # default branch and rejects --prune when it would delete it.
           git push gitlab \
-            --prune \
-            "+refs/heads/*:refs/heads/*" \
-            "+refs/tags/*:refs/tags/*"
+            "refs/heads/*:refs/heads/*"
+
+          # Push tags with force so re-created tags are synced correctly.
+          git push gitlab --force \
+            "refs/tags/*:refs/tags/*"
         env:
           GITLAB_TOKEN: ${{ secrets.GITLAB_MIRROR_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,16 @@ Versioning: [SemVer](https://semver.org/)
 - GitHub Actions workflows: CI (fmt, clippy, test, doc), coverage (cargo-llvm-cov + Codecov), mirror (GitLab), release-drafter (SemVer)
 - GitHub issue templates: bug, feature, maintenance, decision
 - Release-drafter SemVer configuration (`release-drafter-semver-template.yml`)
+- Serialize/Deserialize on all core types: `PhysicalQuantity`, `PhysicalData`, `PhysicalState`,
+  `TemporalInjection`, `Scenario`, `DomainBoundaries`, `SolverType`, `SolverConfiguration`, `SimulationResult`
+- `#[typetag::serde]` on `PhysicalModel` trait and all implementors
+- `ndarray/serde` feature activated — `PhysicalData::Array` fully serializable
+- `typetag = "0.2"`, `serde_yaml = "0.9"` added to dependencies
 
 ### Changed
 - Upgrade `dynamic-cli` dependency from `0.1.1` to `0.2.0`
-- Upgrade `nalgebra` dependency from `0.33` to `0.34`
+- Upgrade `nalgebra` dependency from `0.33` to `0.34.2` with `serde-serialize` feature
+- `PhysicalQuantity::Custom(&'static str)` → `Custom(String)`, `Copy` removed
 - Fix rustdoc redirect in CI: `dynamic_cli/index.html` → `chrom_rs/index.html`
 - Enable and fix all doc-tests across `models/`, `solver/`, and `output/` modules — remove `ignore` attribute, align examples with current public API
 - Add `libfontconfig1-dev` system dependency in CI jobs (required by `plotters`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ Versioning: [SemVer](https://semver.org/)
 - `#[typetag::serde]` on `PhysicalModel` trait and all implementors
 - `ndarray/serde` feature activated — `PhysicalData::Array` fully serializable
 - `typetag = "0.2"`, `serde_yaml = "0.9"` added to dependencies
+- `Exportable` trait (`physics/traits.rs`): `to_map` / `from_map` mapping layer between physical models and JSON — no circular dependency (option A signature)
+- `ExportError`: `MissingKey`, `InvalidValue`, `SpeciesCountMismatch`
+- `outlet_data(quantity, trajectory, idx)`: generic outlet extractor for any `PhysicalQuantity`
+- `sample_indices(total, n)`: uniform downsampling helper, first and last points always included
+- `Exportable` implemented on `LangmuirSingle` and `LangmuirMulti` — named species blocks (`species_N` + `"name"` key), `global` extension point for scalar/vector quantities
+- `output/export/json.rs`: `to_json` / `from_json` — pure I/O layer, `Map<String, Value>` only, no model knowledge
+- `serde_json = "1.0"` added to dependencies
 
 ### Changed
 - Upgrade `dynamic-cli` dependency from `0.1.1` to `0.2.0`
@@ -26,6 +33,7 @@ Versioning: [SemVer](https://semver.org/)
 - Fix rustdoc redirect in CI: `dynamic_cli/index.html` → `chrom_rs/index.html`
 - Enable and fix all doc-tests across `models/`, `solver/`, and `output/` modules — remove `ignore` attribute, align examples with current public API
 - Add `libfontconfig1-dev` system dependency in CI jobs (required by `plotters`)
+- `LangmuirMulti`: add public accessors `porosity`, `velocity`, `column_length`, `spatial_points`, `species_params`
 
 ### Removed
 - Untrack `langmuir_single_simple.rs` (out of scope, kept locally)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ num = "0.4.3"
 serde = { version = "1.0.228", features = ["derive"] }
 typetag = "0.2"
 log = "0.4.29"
-serde_json = "1"
+serde_json = "1.0"
 serde_yaml = "0.9"
 anyhow = "1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ plotters = "0.3"
 
 # Parallelism (optional)
 rayon = { version = "1.11", optional = true }
-ndarray = "0.17.2"
+ndarray = { version = "0.17.2", features = ["serde"] }
 
 [dev-dependencies]
 approx = "0.5.1"

--- a/benches/solver_performance.rs
+++ b/benches/solver_performance.rs
@@ -64,9 +64,9 @@ use chrom_rs::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalS
 use chrom_rs::solver::{DomainBoundaries, Scenario, Solver, SolverConfiguration};
 use chrom_rs::solver::{EulerSolver, RK4Solver};
 use criterion::{BenchmarkId, Criterion, SamplingMode, criterion_group, criterion_main};
+use serde::{Deserialize, Serialize};
 use std::hint::black_box;
 use std::time::Duration;
-
 // =================================================================================================
 // Simple Model for Benchmarking
 // =================================================================================================
@@ -92,10 +92,12 @@ use std::time::Duration;
 ///
 /// This is a **stiff problem** for k > 1, but k=0.1 is mild,
 /// making it suitable for testing basic solver performance.
+#[derive(Deserialize, Serialize)]
 struct SimpleModel {
     points: usize,
 }
 
+#[typetag::serde]
 impl PhysicalModel for SimpleModel {
     fn points(&self) -> usize {
         self.points

--- a/examples/diffusion.rs
+++ b/examples/diffusion.rs
@@ -12,9 +12,11 @@ use chrom_rs::{
     solver::{DomainBoundaries, EulerSolver, RK4Solver, Scenario, Solver, SolverConfiguration},
 };
 use nalgebra::DVector;
+use serde::{Deserialize, Serialize};
 use std::error::Error;
 
 /// Fisher-KPP diffusion-reaction model
+#[derive(Serialize, Deserialize)]
 struct FisherKPP {
     n_points: usize,
     length: f64,
@@ -47,6 +49,7 @@ impl FisherKPP {
     }
 }
 
+#[typetag::serde]
 impl PhysicalModel for FisherKPP {
     fn points(&self) -> usize {
         self.n_points

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,11 @@
 //! use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 //! use chrom_rs::solver::{EulerSolver, Solver, SolverConfiguration, Scenario, DomainBoundaries};
 //! use nalgebra::DVector;
+//! use serde::{Deserialize, Serialize};
 //!
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }

--- a/src/models/injection.rs
+++ b/src/models/injection.rs
@@ -27,6 +27,7 @@
 //! assert!(injection.evaluate(20.0) < 1e-3);    // After injection (nearly zero)
 //! ```
 
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// Temporal injection profile at column inlet
 ///
 /// Defines how C(z=0, t) varies with time.
@@ -38,6 +39,38 @@
 /// - **Rectangle**: Constant injection for a duration
 /// - **Custom**: User-defined temporal profile
 use std::sync::Arc;
+
+// ==================== Serialisation snapshot (internal) ====================
+
+/// Internal representation for serde serialisation of [`TemporalInjection`].
+///
+/// Mirrors all serialisable variants of [`TemporalInjection`].
+/// [`TemporalInjection::Custom`] is excluded — closures cannot be serialised.
+///
+/// The `type` field is used as a tag in the JSON/YAML output:
+/// ```json
+/// { "type": "Dirac", "time": 5.0, "amount": 0.1 }
+/// ```
+#[derive(Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum TemporalInjectionSnapshot {
+    Dirac {
+        time: f64,
+        amount: f64,
+    },
+    Gaussian {
+        center: f64,
+        width: f64,
+        peak_concentration: f64,
+    },
+    Rectangle {
+        start: f64,
+        end: f64,
+        concentration: f64,
+    },
+    None,
+}
+
 pub enum TemporalInjection {
     /// Dirac delta injection at a single time point
     ///
@@ -192,6 +225,90 @@ impl std::fmt::Debug for TemporalInjection {
                 .finish(),
             Self::None => f.debug_struct("None").finish(),
         }
+    }
+}
+
+// ==================== Manual Serialize Implementation ====================
+
+/// Serialises [`TemporalInjection`] to JSON/YAML via [`TemporalInjectionSnapshot`].
+///
+/// # Errors
+///
+/// Returns a serialisation error if called on [`TemporalInjection::Custom`],
+/// which holds a closure that cannot be represented in a data format.
+impl Serialize for TemporalInjection {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let snapshot = match self {
+            Self::Dirac { time, amount } => TemporalInjectionSnapshot::Dirac {
+                time: *time,
+                amount: *amount,
+            },
+            Self::Gaussian {
+                center,
+                width,
+                peak_concentration,
+            } => TemporalInjectionSnapshot::Gaussian {
+                center: *center,
+                width: *width,
+                peak_concentration: *peak_concentration,
+            },
+            Self::Rectangle {
+                start,
+                end,
+                concentration,
+            } => TemporalInjectionSnapshot::Rectangle {
+                start: *start,
+                end: *end,
+                concentration: *concentration,
+            },
+            Self::None => TemporalInjectionSnapshot::None,
+            Self::Custom(_) => {
+                return Err(serde::ser::Error::custom(
+                    "Temporal Injection::Custom cannot be serialized",
+                ));
+            }
+        };
+        snapshot.serialize(serializer)
+    }
+}
+
+// ==================== Manual Deserialize Implementation ====================
+
+/// Deserializes [`TemporalInjection`] from JSON/YAML via [`TemporalInjectionSnapshot`].
+///
+/// [`TemporalInjection::Custom`] cannot be deserialized — it must be constructed
+/// programmatically via [`TemporalInjection::custom`].
+impl<'de> Deserialize<'de> for TemporalInjection {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let snapshot = match TemporalInjectionSnapshot::deserialize(deserializer)? {
+            TemporalInjectionSnapshot::Dirac { time, amount } => Self::Dirac { time, amount },
+            TemporalInjectionSnapshot::Gaussian {
+                center,
+                width,
+                peak_concentration,
+            } => Self::Gaussian {
+                center,
+                width,
+                peak_concentration,
+            },
+            TemporalInjectionSnapshot::Rectangle {
+                start,
+                end,
+                concentration,
+            } => Self::Rectangle {
+                start,
+                end,
+                concentration,
+            },
+            TemporalInjectionSnapshot::None => Self::None,
+        };
+        Ok(snapshot)
     }
 }
 
@@ -543,5 +660,86 @@ mod tests {
 
         assert_eq!(clone.evaluate(0.0), 0.0);
         assert_eq!(clone.evaluate(100.0), 0.0);
+    }
+
+    // ==================== Serde round-trip tests ====================
+
+    #[test]
+    fn test_serialize_dirac() {
+        let injection = TemporalInjection::dirac(5.0, 0.1);
+        let json = serde_json::to_string(&injection).unwrap();
+        assert!(json.contains("\"type\":\"Dirac\""));
+        assert!(json.contains("\"time\":5.0"));
+        assert!(json.contains("\"amount\":0.1"));
+    }
+
+    #[test]
+    fn test_serialize_gaussian() {
+        let injection = TemporalInjection::gaussian(10.0, 3.0, 0.1);
+        let json = serde_json::to_string(&injection).unwrap();
+        assert!(json.contains("\"type\":\"Gaussian\""));
+        assert!(json.contains("\"center\":10.0"));
+    }
+
+    #[test]
+    fn test_serialize_rectangle() {
+        let injection = TemporalInjection::rectangle(5.0, 15.0, 0.05);
+        let json = serde_json::to_string(&injection).unwrap();
+        assert!(json.contains("\"type\":\"Rectangle\""));
+        assert!(json.contains("\"start\":5.0"));
+        assert!(json.contains("\"end\":15.0"));
+    }
+
+    #[test]
+    fn test_serialize_none() {
+        let injection = TemporalInjection::none();
+        let json = serde_json::to_string(&injection).unwrap();
+        assert!(json.contains("\"type\":\"None\""));
+    }
+
+    #[test]
+    fn test_serialize_custom_fails() {
+        let injection = TemporalInjection::custom(|t| t);
+        assert!(serde_json::to_string(&injection).is_err());
+    }
+
+    #[test]
+    fn test_round_trip_dirac() {
+        let original = TemporalInjection::dirac(5.0, 0.1);
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: TemporalInjection = serde_json::from_str(&json).unwrap();
+        assert!((restored.evaluate(5.0) - original.evaluate(5.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_round_trip_gaussian() {
+        let original = TemporalInjection::gaussian(10.0, 3.0, 0.1);
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: TemporalInjection = serde_json::from_str(&json).unwrap();
+        assert!((restored.evaluate(10.0) - original.evaluate(10.0)).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_round_trip_rectangle() {
+        let original = TemporalInjection::rectangle(5.0, 15.0, 0.05);
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: TemporalInjection = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.evaluate(10.0), original.evaluate(10.0));
+    }
+
+    #[test]
+    fn test_round_trip_none() {
+        let original = TemporalInjection::none();
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: TemporalInjection = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.evaluate(0.0), 0.0);
+    }
+
+    #[test]
+    fn test_round_trip_yaml() {
+        let original = TemporalInjection::dirac(5.0, 0.1);
+        let yaml = serde_yaml::to_string(&original).unwrap();
+        let restored: TemporalInjection = serde_yaml::from_str(&yaml).unwrap();
+        assert!((restored.evaluate(5.0) - original.evaluate(5.0)).abs() < 1e-10);
     }
 }

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -79,6 +79,7 @@
 //! ```
 
 use nalgebra::{DMatrix, DVector};
+use serde::{Deserialize, Serialize};
 
 use crate::models::injection::TemporalInjection;
 use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
@@ -126,7 +127,7 @@ use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalStat
 /// );
 /// assert!(malic.validate().is_ok());
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpeciesParams {
     /// Species name (used for plot legends and CSV headers)
     pub name: String,
@@ -276,7 +277,7 @@ impl SpeciesParams {
 /// model.add_species(third_species).unwrap();   // Jacobian: 2×2 → 3×3
 /// model.add_species(fourth_species).unwrap();    // Jacobian: 3×3 → 4×4
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 #[allow(dead_code)]
 pub struct LangmuirMulti {
     /// Chemical species (at least 1, extensible via \[`add_species`\](Self::add_species))
@@ -538,6 +539,7 @@ impl LangmuirMulti {
 // PhysicalModel implementation
 // =================================================================================================
 
+#[typetag::serde]
 impl PhysicalModel for LangmuirMulti {
     /// Returns the number of spatial discretization points (row dimension of the state matrix)
     fn points(&self) -> usize {

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -80,9 +80,14 @@
 
 use nalgebra::{DMatrix, DVector};
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
 
 use crate::models::injection::TemporalInjection;
-use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
+use crate::physics::{
+    ExportError, Exportable, PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState,
+    outlet_data, sample_indices,
+};
 
 // =================================================================================================
 // SpeciesParams — Physical parameters of a chemical species
@@ -449,6 +454,22 @@ impl LangmuirMulti {
         self.species.len()
     }
 
+    pub fn porosity(&self) -> f64 {
+        self.porosity
+    }
+    pub fn velocity(&self) -> f64 {
+        self.velocity
+    }
+    pub fn column_length(&self) -> f64 {
+        self.column_length
+    }
+    pub fn spatial_points(&self) -> usize {
+        self.n_points
+    }
+    pub fn species_params(&self) -> &[SpeciesParams] {
+        &self.species
+    }
+
     /// Returns species names in insertion order
     ///
     /// The order matches column indices of the state matrix `[n_points × n_species]`.
@@ -764,6 +785,262 @@ impl PhysicalModel for LangmuirMulti {
             "Competitive Langmuir adsorption model for n species \
              with upwind spatial discretisation and matrix Jacobian inversion.",
         )
+    }
+}
+
+impl Exportable for LangmuirMulti {
+    /// Builds the export map for a multi-species Langmuir simulation.
+    ///
+    /// Each species is serialised as a named block under `"profiles"`.
+    /// The `"name"` key is colocated with the species data so that identity
+    /// and measurements travel together — preventing species permutation on
+    /// reload.
+    ///
+    /// # JSON layout
+    ///
+    /// ```json
+    /// {
+    ///   "metadata": {
+    ///     "model":     "Langmuir multi species with temporal injection",
+    ///     "n_species": 2,
+    ///     "nz":        150,
+    ///     "porosity":  0.4,
+    ///     "velocity":  0.001,
+    ///     "length":    0.25,
+    ///     "species": [
+    ///       { "name": "Malic",  "lambda": 1.0, "langmuir_k": 0.5, "port_number": 1 },
+    ///       { "name": "Citric", "lambda": 1.0, "langmuir_k": 2.0, "port_number": 1 }
+    ///     ]
+    ///   },
+    ///   "data": {
+    ///     "time_points": [0.0, 0.1, "..."],
+    ///     "profiles": {
+    ///       "species_0": { "name": "Malic",  "Concentration": ["..."] },
+    ///       "species_1": { "name": "Citric", "Concentration": ["..."] },
+    ///       "global":    {}
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// The `"global"` block is included but empty by default — it is the
+    /// extension point for future scalar or vector quantities (temperature,
+    /// pressure, etc.) that are not species-specific.
+    ///
+    /// # Dispatch rule
+    ///
+    /// `PhysicalData::Matrix [n_points × n_species]` → `"species_N"` blocks.
+    /// `PhysicalData::Scalar` or `Vector [n_points]`  → `"global"` block.
+    fn to_map(
+        &self,
+        time_points: &[f64],
+        trajectory: &[crate::physics::PhysicalState],
+        metadata: &HashMap<String, String>,
+    ) -> Map<String, Value> {
+        let mut root = Map::new();
+
+        // ── metadata ──────────────────────────────────────────────────────────
+        let species_meta: Vec<Value> = self
+            .species_params()
+            .iter()
+            .map(|s| {
+                json!({
+                    "name":        s.name,
+                    "lambda":      s.lambda,
+                    "langmuir_k":  s.langmuir_k,
+                    "port_number": s.port_number,
+                })
+            })
+            .collect();
+
+        let mut meta: Map<String, Value> = [
+            ("model", Value::String(self.name().into())),
+            ("n_species", Value::from(self.n_species() as u64)),
+            ("nz", Value::from(self.spatial_points() as u64)),
+            ("porosity", Value::from(self.porosity())),
+            ("velocity", Value::from(self.velocity())),
+            ("length", Value::from(self.column_length())),
+            ("species", Value::Array(species_meta)),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+        // Merge solver metadata — model keys take precedence
+        for (k, v) in metadata {
+            meta.entry(k.clone())
+                .or_insert_with(|| Value::String(v.clone()));
+        }
+
+        root.insert("metadata".into(), Value::Object(meta));
+
+        // ── data ──────────────────────────────────────────────────────────────
+        let indices = sample_indices(time_points.len(), None);
+
+        let tp_values: Vec<Value> = indices
+            .iter()
+            .map(|&i| Value::from(time_points[i]))
+            .collect();
+
+        let names = self.species_names();
+        let n = names.len();
+
+        // Build one concentration Vec per species across all sampled steps
+        let mut per_species: Vec<Vec<Value>> = vec![Vec::with_capacity(indices.len()); n];
+        for &i in &indices {
+            let outlet = outlet_data(PhysicalQuantity::Concentration, trajectory, i);
+            for (s, col) in per_species.iter_mut().enumerate() {
+                col.push(Value::from(*outlet.get(s).unwrap_or(&0.0)));
+            }
+        }
+
+        let mut profiles = Map::new();
+        for (s, conc_vals) in per_species.into_iter().enumerate() {
+            let mut block = Map::new();
+            block.insert("name".into(), Value::String(names[s].to_string()));
+            block.insert("Concentration".into(), Value::Array(conc_vals));
+            profiles.insert(format!("species_{s}"), Value::Object(block));
+        }
+        // Extension point for future scalar/vector quantities
+        profiles.insert("global".into(), Value::Object(Map::new()));
+
+        root.insert(
+            "data".into(),
+            json!({
+                "time_points": tp_values,
+                "profiles":    profiles,
+            }),
+        );
+
+        root
+    }
+
+    /// Reconstructs a `LangmuirMulti` configuration from an export map.
+    ///
+    /// # Required keys in `metadata`
+    ///
+    /// | Key | Type | Description |
+    /// |---|---|---|
+    /// | `nz` | `u64` | Number of spatial points |
+    /// | `porosity` | `f64` | Extra-granular porosity ε ∈ (0, 1) |
+    /// | `velocity` | `f64` | Superficial velocity (m/s) |
+    /// | `length` | `f64` | Column length (m) |
+    /// | `species` | array | Per-species parameters (see below) |
+    ///
+    /// Each entry in `metadata.species` must contain:
+    /// `name` (string), `lambda` (f64), `langmuir_k` (f64), `port_number` (u64).
+    ///
+    /// The injection profile is not serialised. It defaults to
+    /// [`TemporalInjection::none`] for each species and must be overridden
+    /// by the caller after reconstruction if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::MissingKey`] if a required key is absent,
+    /// [`ExportError::InvalidValue`] if a value has the wrong type or model
+    /// construction fails, or [`ExportError::SpeciesCountMismatch`] if the
+    /// species list is empty.
+    fn from_map(map: Map<String, Value>) -> Result<Self, ExportError>
+    where
+        Self: Sized,
+    {
+        let meta = map
+            .get("metadata")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| ExportError::MissingKey("metadata".into()))?;
+
+        macro_rules! get_f64 {
+            ($key:expr) => {
+                meta.get($key)
+                    .and_then(|v| v.as_f64())
+                    .ok_or_else(|| ExportError::MissingKey($key.into()))?
+            };
+        }
+        macro_rules! get_usize {
+            ($key:expr) => {
+                meta.get($key)
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as usize)
+                    .ok_or_else(|| ExportError::MissingKey($key.into()))?
+            };
+        }
+
+        let nz = get_usize!("nz");
+        let porosity = get_f64!("porosity");
+        let velocity = get_f64!("velocity");
+        let length = get_f64!("length");
+
+        let species_arr = meta
+            .get("species")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| ExportError::MissingKey("metadata.species".into()))?;
+
+        if species_arr.is_empty() {
+            return Err(ExportError::SpeciesCountMismatch {
+                expected: 1,
+                got: 0,
+            });
+        }
+
+        let mut params: Vec<SpeciesParams> = Vec::with_capacity(species_arr.len());
+        for (i, s) in species_arr.iter().enumerate() {
+            let obj = s.as_object().ok_or_else(|| ExportError::InvalidValue {
+                key: format!("metadata.species[{i}]"),
+                reason: "expected object".into(),
+            })?;
+
+            macro_rules! field_f64 {
+                ($key:expr) => {
+                    obj.get($key).and_then(|v| v.as_f64()).ok_or_else(|| {
+                        ExportError::MissingKey(format!("metadata.species[{i}].{}", $key))
+                    })?
+                };
+            }
+            macro_rules! field_u32 {
+                ($key:expr) => {
+                    obj.get($key)
+                        .and_then(|v| v.as_u64())
+                        .map(|v| v as u32)
+                        .ok_or_else(|| {
+                            ExportError::MissingKey(format!("metadata.species[{i}].{}", $key))
+                        })?
+                };
+            }
+
+            let name = obj
+                .get("name")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ExportError::MissingKey(format!("metadata.species[{i}].name")))?
+                .to_string();
+
+            params.push(SpeciesParams::new(
+                &name,
+                field_f64!("lambda"),
+                field_f64!("langmuir_k"),
+                field_u32!("port_number"),
+                TemporalInjection::none(),
+            ));
+        }
+
+        let first = params.remove(0);
+        let mut model =
+            LangmuirMulti::new(vec![first], nz, porosity, velocity, length).map_err(|e| {
+                ExportError::InvalidValue {
+                    key: "metadata".into(),
+                    reason: e,
+                }
+            })?;
+
+        for sp in params {
+            model
+                .add_species(sp)
+                .map_err(|e| ExportError::InvalidValue {
+                    key: "metadata.species".into(),
+                    reason: e,
+                })?;
+        }
+
+        Ok(model)
     }
 }
 

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -97,9 +97,14 @@
 //! ```
 
 use crate::models::TemporalInjection;
-use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
+use crate::physics::{
+    ExportError, Exportable, PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState,
+    outlet_data, sample_indices,
+};
 use nalgebra::DVector;
 use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::collections::HashMap;
 
 // =================================================================================================
 // LangmuirSingle
@@ -440,6 +445,172 @@ impl PhysicalModel for LangmuirSingle {
             "Using Langmuir isotherm with time varying inlet BC. \
         Read from Physical State metadata.",
         )
+    }
+}
+
+impl Exportable for LangmuirSingle {
+    /// Builds the export map for a single-species Langmuir simulation.
+    ///
+    /// # JSON layout
+    ///
+    /// ```json
+    /// {
+    ///   "metadata": {
+    ///     "model":       "Langmuir single specie with temporal injection",
+    ///     "lambda":      1.2,
+    ///     "langmuir_k":  0.4,
+    ///     "port_number": 2.0,
+    ///     "length":      0.25,
+    ///     "nz":          100,
+    ///     "fe":          1.5,
+    ///     "ue":          0.0025,
+    ///     "solver":      "Runge-Kutta 4",
+    ///     "dt":          "0.06"
+    ///   },
+    ///   "data": {
+    ///     "time_points": [0.0, 0.06, "..."],
+    ///     "profiles": {
+    ///       "species_0": { "Concentration": [0.0, 1.2e-4, "..."] }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// No `"name"` key appears under `"species_0"` — `LangmuirSingle` models
+    /// a single anonymous species by design.
+    ///
+    /// Solver metadata (`solver`, `dt`, `total time`, …) is merged from the
+    /// `metadata` argument. Model parameters take precedence on key collision.
+    fn to_map(
+        &self,
+        time_points: &[f64],
+        trajectory: &[crate::physics::PhysicalState],
+        metadata: &HashMap<String, String>,
+    ) -> Map<String, Value> {
+        let mut root = Map::new();
+
+        // ── metadata ──────────────────────────────────────────────────────────
+        let mut meta: Map<String, Value> = [
+            ("model", Value::String(self.name().into())),
+            ("lambda", Value::from(self.lambda)),
+            ("langmuir_k", Value::from(self.langmuir_k)),
+            ("port_number", Value::from(self.port_number)),
+            ("length", Value::from(self.length)),
+            ("nz", Value::from(self.nz as u64)),
+            ("fe", Value::from(self.fe)),
+            ("ue", Value::from(self.ue)),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v))
+        .collect();
+
+        // Merge solver metadata — model keys take precedence
+        for (k, v) in metadata {
+            meta.entry(k.clone())
+                .or_insert_with(|| Value::String(v.clone()));
+        }
+
+        root.insert("metadata".into(), Value::Object(meta));
+
+        // ── data ──────────────────────────────────────────────────────────────
+        let indices = sample_indices(time_points.len(), None);
+
+        let tp_values: Vec<Value> = indices
+            .iter()
+            .map(|&i| Value::from(time_points[i]))
+            .collect();
+
+        let concentrations: Vec<Value> = indices
+            .iter()
+            .map(|&i| {
+                let c = outlet_data(PhysicalQuantity::Concentration, trajectory, i);
+                Value::from(*c.first().unwrap_or(&0.0))
+            })
+            .collect();
+
+        root.insert(
+            "data".into(),
+            json!({
+                "time_points": tp_values,
+                "profiles": {
+                    "species_0": { "Concentration": concentrations }
+                }
+            }),
+        );
+
+        root
+    }
+
+    /// Reconstructs a `LangmuirSingle` configuration from an export map.
+    ///
+    /// # Required keys in `metadata`
+    ///
+    /// | Key | Type | Description |
+    /// |---|---|---|
+    /// | `lambda` | `f64` | Linear retention term |
+    /// | `langmuir_k` | `f64` | Langmuir equilibrium constant |
+    /// | `port_number` | `f64` | Adsorption capacity |
+    /// | `length` | `f64` | Column length (m) |
+    /// | `nz` | `u64` | Number of spatial points |
+    /// | `fe` | `f64` | Phase ratio — back-computes porosity as `1 / (1 + fe)` |
+    /// | `ue` | `f64` | Interstitial velocity — back-computes velocity as `ue × ε` |
+    ///
+    /// The injection profile is not serialised. It defaults to
+    /// [`TemporalInjection::none`] and must be overridden by the caller if needed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError::MissingKey`] if a required key is absent, or
+    /// [`ExportError::InvalidValue`] if a value has the wrong type.
+    fn from_map(map: Map<String, Value>) -> Result<Self, ExportError>
+    where
+        Self: Sized,
+    {
+        let meta = map
+            .get("metadata")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| ExportError::MissingKey("metadata".into()))?;
+
+        macro_rules! get_f64 {
+            ($key:expr) => {
+                meta.get($key)
+                    .and_then(|v| v.as_f64())
+                    .ok_or_else(|| ExportError::MissingKey($key.into()))?
+            };
+        }
+        macro_rules! get_usize {
+            ($key:expr) => {
+                meta.get($key)
+                    .and_then(|v| v.as_u64())
+                    .map(|v| v as usize)
+                    .ok_or_else(|| ExportError::MissingKey($key.into()))?
+            };
+        }
+
+        let lambda = get_f64!("lambda");
+        let langmuir_k = get_f64!("langmuir_k");
+        let port_number = get_f64!("port_number");
+        let length = get_f64!("length");
+        let fe = get_f64!("fe");
+        let ue = get_f64!("ue");
+        let nz = get_usize!("nz");
+
+        // Back-compute constructor arguments from derived quantities:
+        //   fe = (1 - ε) / ε  →  ε = 1 / (1 + fe)
+        //   ue = u / ε         →  u = ue × ε
+        let porosity = 1.0 / (1.0 + fe);
+        let velocity = ue * porosity;
+
+        Ok(LangmuirSingle::new(
+            lambda,
+            langmuir_k,
+            port_number,
+            porosity,
+            velocity,
+            length,
+            nz,
+            TemporalInjection::none(),
+        ))
     }
 }
 

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -99,6 +99,7 @@
 use crate::models::TemporalInjection;
 use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
 use nalgebra::DVector;
+use serde::{Deserialize, Serialize};
 
 // =================================================================================================
 // LangmuirSingle
@@ -144,7 +145,7 @@ use nalgebra::DVector;
 /// assert_eq!(model.length(), 0.25);
 /// assert_eq!(model.spatial_points(), 100);
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct LangmuirSingle {
     // ── Isotherm parameters ───────────────────────────────────────────────────
     /// Linear retention term $\lambda$ **\[dimensionless\]**, must be $\geq 0$
@@ -324,6 +325,7 @@ impl LangmuirSingle {
 // PhysicalModel implementation
 // =================================================================================================
 
+#[typetag::serde]
 impl PhysicalModel for LangmuirSingle {
     /// Returns the number of spatial discretisation points $N_z$
     fn points(&self) -> usize {

--- a/src/output/export/json.rs
+++ b/src/output/export/json.rs
@@ -1,0 +1,222 @@
+//! JSON export and import for simulation results.
+//!
+//! # Design
+//!
+//! This module provides two **universal** functions that operate on a
+//! `serde_json::Map` — the exchange format produced by
+//! [`crate::physics::Exportable::to_map`].
+//!
+//! The functions have no knowledge of physical models: they read and write
+//! JSON files from/to a generic map. All domain-specific structure lives in
+//! the [`Exportable`](crate::physics::Exportable) implementations on the
+//! model types.
+//!
+//! # Responsibilities
+//!
+//! This module is **I/O only**. It does not know about physical models,
+//! `SimulationResult`, or any domain type. The full pipeline is:
+//!
+//! ```text
+//! CLI layer
+//!   model.to_map(&time_points, &trajectory, &metadata)  →  Map<String, Value>
+//!   to_json(&map, path)                                  →  file
+//!   from_json(path)                                      →  Map<String, Value>
+//!   Model::from_map(map)                                 →  model
+//! ```
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use chrom_rs::output::export::json::{to_json, from_json};
+//! use serde_json::{Map, Value, json};
+//!
+//! // Produced by model.to_map(...) in the CLI layer
+//! let map: Map<String, Value> = json!({
+//!     "metadata": { "solver": "RK4", "model": "LangmuirSingle" },
+//!     "data": {
+//!         "time_points": [0.0, 0.06, 0.12],
+//!         "profiles": {
+//!             "species_0": { "Concentration": [0.0, 1.2e-4, 2.1e-4] }
+//!         }
+//!     }
+//! })
+//! .as_object()
+//! .cloned()
+//! .unwrap();
+//!
+//! to_json(&map, "/tmp/result.json").unwrap();
+//! let reloaded = from_json("/tmp/result.json").unwrap();
+//! ```
+
+use serde_json::{Map, Value};
+use std::fmt;
+use std::fs::File;
+use std::io::{BufReader, BufWriter};
+
+// ============================================================================
+// JsonError
+// ============================================================================
+
+/// Errors that can occur during JSON file I/O.
+#[derive(Debug)]
+pub enum JsonError {
+    /// System error: unable to open, read, or write the file.
+    Io(std::io::Error),
+
+    /// The file content is not valid JSON, or the JSON structure is unexpected.
+    Serialization(serde_json::Error),
+}
+
+impl fmt::Display for JsonError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            JsonError::Io(e) => write!(f, "JSON I/O error: {e}"),
+            JsonError::Serialization(e) => write!(f, "JSON serialization error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for JsonError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            JsonError::Io(e) => Some(e),
+            JsonError::Serialization(e) => Some(e),
+        }
+    }
+}
+
+impl From<std::io::Error> for JsonError {
+    fn from(e: std::io::Error) -> Self {
+        JsonError::Io(e)
+    }
+}
+
+impl From<serde_json::Error> for JsonError {
+    fn from(e: serde_json::Error) -> Self {
+        JsonError::Serialization(e)
+    }
+}
+
+// ============================================================================
+// Universal I/O functions
+// ============================================================================
+
+/// Writes a JSON map to a file (pretty-printed).
+///
+/// The map is typically produced by
+/// [`Exportable::to_map`](crate::physics::export::Exportable::to_map).
+///
+/// # Errors
+///
+/// - [`JsonError::Io`] if the file cannot be created or written.
+/// - [`JsonError::Serialization`] if the map cannot be serialized (unlikely
+///   for maps produced by `to_map`).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::output::export::json::to_json;
+/// use serde_json::{Map, Value};
+///
+/// let mut map = Map::new();
+/// map.insert("key".into(), Value::from(42.0));
+/// let _ = to_json(&map, "/tmp/test.json");
+/// ```
+pub fn to_json(map: &Map<String, Value>, path: &str) -> Result<(), JsonError> {
+    let file = File::create(path)?;
+    let writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(writer, map)?;
+    Ok(())
+}
+
+/// Reads a JSON file and returns its content as a generic map.
+///
+/// The map can then be passed to
+/// [`Exportable::from_map`](crate::physics::export::Exportable::from_map)
+/// to reconstruct a physical model.
+///
+/// # Errors
+///
+/// - [`JsonError::Io`] if the file cannot be opened or read.
+/// - [`JsonError::Serialization`] if the file content is not a valid JSON
+///   object (arrays and primitives at the top level are rejected).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::output::export::json::from_json;
+///
+/// let map = from_json("/tmp/result.json");
+/// ```
+pub fn from_json(path: &str) -> Result<Map<String, Value>, JsonError> {
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let value: Value = serde_json::from_reader(reader)?;
+    value.as_object().cloned().ok_or_else(|| {
+        JsonError::Serialization(serde_json::from_str::<Value>("not_an_object").unwrap_err())
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn make_map() -> Map<String, Value> {
+        let v = json!({
+            "metadata": { "solver": "RK4", "model": "TestModel" },
+            "data": {
+                "time_points": [0.0, 1.0, 2.0],
+                "profiles": {
+                    "species_0": { "Concentration": [0.0, 0.5, 1.0] }
+                }
+            }
+        });
+        v.as_object().cloned().unwrap()
+    }
+
+    #[test]
+    fn test_to_json_creates_file() {
+        let map = make_map();
+        let path = "/tmp/chrom_rs_test_json.json";
+        to_json(&map, path).expect("to_json should succeed");
+        assert!(std::path::Path::new(path).exists());
+    }
+
+    #[test]
+    fn test_round_trip() {
+        let original = make_map();
+        let path = "/tmp/chrom_rs_test_roundtrip.json";
+
+        to_json(&original, path).expect("write");
+        let loaded = from_json(path).expect("read");
+
+        // metadata.solver must survive the round-trip
+        let solver = loaded["metadata"]["solver"].as_str().unwrap();
+        assert_eq!(solver, "RK4");
+
+        // time_points must survive
+        let tp = loaded["data"]["time_points"].as_array().unwrap();
+        assert_eq!(tp.len(), 3);
+        assert!((tp[1].as_f64().unwrap() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_from_json_missing_file() {
+        let result = from_json("/tmp/does_not_exist_chrom_rs.json");
+        assert!(matches!(result, Err(JsonError::Io(_))));
+    }
+
+    #[test]
+    fn test_from_json_not_object() {
+        // Write a JSON array — not a top-level object
+        let path = "/tmp/chrom_rs_test_array.json";
+        std::fs::write(path, "[1, 2, 3]").unwrap();
+        let result = from_json(path);
+        assert!(matches!(result, Err(JsonError::Serialization(_))));
+    }
+}

--- a/src/output/export/mod.rs
+++ b/src/output/export/mod.rs
@@ -48,13 +48,14 @@
 //! ```
 
 pub mod csv;
+pub mod json;
 
 // Re-export the most commonly used types at the module level so users can write:
 //   use chrom_rs::output::export::{CsvExporter, CsvConfig, CsvError};
 // instead of the full sub-module path.
-pub use csv::{CsvConfig, CsvError, CsvExporter};
-
 use crate::solver::SimulationResult;
+pub use csv::{CsvConfig, CsvError, CsvExporter};
+pub use json::{JsonError, from_json, to_json};
 
 /// Abstraction trait for all export formats.
 ///

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -75,4 +75,4 @@ pub use visualization::{
     plot_profile_evolution, plot_steady_state, plot_steady_state_comparison,
 };
 
-pub use export::{CsvConfig, CsvError, CsvExporter, from_json, to_json, JsonError};
+pub use export::{CsvConfig, CsvError, CsvExporter, JsonError, from_json, to_json};

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -75,4 +75,4 @@ pub use visualization::{
     plot_profile_evolution, plot_steady_state, plot_steady_state_comparison,
 };
 
-pub use export::{CsvConfig, CsvError, CsvExporter};
+pub use export::{CsvConfig, CsvError, CsvExporter, from_json, to_json, JsonError};

--- a/src/output/visualization/chromatogram.rs
+++ b/src/output/visualization/chromatogram.rs
@@ -869,16 +869,18 @@ mod tests {
     use crate::physics::{PhysicalModel, PhysicalQuantity, PhysicalState};
     use crate::solver::{DomainBoundaries, EulerSolver, Scenario, Solver, SolverConfiguration};
     use nalgebra::{DMatrix, DVector};
-
+    use serde::{Deserialize, Serialize};
     // ─────────────────────────────────────────────────────────────────────────
     // Test models
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Single-species model (Vector state) — mimics LangmuirSingle
+    #[derive(Serialize, Deserialize)]
     struct SingleModel {
         n_points: usize,
     }
 
+    #[typetag::serde]
     impl PhysicalModel for SingleModel {
         fn points(&self) -> usize {
             self.n_points
@@ -906,11 +908,13 @@ mod tests {
     }
 
     /// Multi-species model (Matrix state) — mimics LangmuirMulti
+    #[derive(Serialize, Deserialize)]
     struct MultiModel {
         n_points: usize,
         n_species: usize,
     }
 
+    #[typetag::serde]
     impl PhysicalModel for MultiModel {
         fn points(&self) -> usize {
             self.n_points

--- a/src/output/visualization/steady.rs
+++ b/src/output/visualization/steady.rs
@@ -587,16 +587,18 @@ mod tests {
     use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
     use crate::solver::{DomainBoundaries, EulerSolver, Scenario, Solver, SolverConfiguration};
     use nalgebra::{DMatrix, DVector};
-
+    use serde::{Deserialize, Serialize};
     // ─────────────────────────────────────────────────────────────────────────
     // Test models
     // ─────────────────────────────────────────────────────────────────────────
 
     /// Single-species model: Gaussian initial profile with uniform decay
+    #[derive(Deserialize, Serialize)]
     struct SingleModel {
         n_points: usize,
     }
 
+    #[typetag::serde]
     impl PhysicalModel for SingleModel {
         fn points(&self) -> usize {
             self.n_points
@@ -627,11 +629,13 @@ mod tests {
     }
 
     /// Multi-species model: n_species columns with species-dependent amplitudes
+    #[derive(Deserialize, Serialize)]
     struct MultiModel {
         n_points: usize,
         n_species: usize,
     }
 
+    #[typetag::serde]
     impl PhysicalModel for MultiModel {
         fn points(&self) -> usize {
             self.n_points

--- a/src/physics/data.rs
+++ b/src/physics/data.rs
@@ -1607,7 +1607,7 @@ mod tests {
 
     #[test]
     fn test_shape() {
-        assert_eq!(PhysicalData::Scalar(1.0).shape(), vec![]);
+        assert_eq!(PhysicalData::Scalar(1.0).shape(), Vec::<usize>::new());
         assert_eq!(PhysicalData::uniform_vector(10, 1.0).shape(), vec![10]);
         assert_eq!(
             PhysicalData::uniform_matrix(10, 3, 1.0).shape(),

--- a/src/physics/data.rs
+++ b/src/physics/data.rs
@@ -94,7 +94,6 @@ pub enum PhysicalData {
     /// - 2D spatial + species: A[x, y, species]
     /// - 3D spatial + species: A[x, y, z, species]
     /// - Time series + spatial: A[time, x, y]
-
     Array(ArrayD<f64>),
 }
 

--- a/src/physics/data.rs
+++ b/src/physics/data.rs
@@ -94,7 +94,7 @@ pub enum PhysicalData {
     /// - 2D spatial + species: A[x, y, species]
     /// - 3D spatial + species: A[x, y, z, species]
     /// - Time series + spatial: A[time, x, y]
-    #[serde(skip)]
+
     Array(ArrayD<f64>),
 }
 

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -24,8 +24,11 @@
 //!
 //! ```rust
 //! use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
+//! use serde::{Deserialize, Serialize};
 //!
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -52,11 +55,14 @@
 //!
 //! ```rust
 //! use chrom_rs::physics::{PhysicalModel, PhysicalState};
+//! use serde::{Deserialize, Serialize};
 //!
+//! #[derive(Deserialize, Serialize)]
 //! struct MyCustomModel {
 //!     // Model parameters
 //! }
 //!
+//! #[typetag::serde]
 //! impl PhysicalModel for MyCustomModel {
 //!     fn points(&self) -> usize {
 //!         // Return number of spatial points

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -99,4 +99,7 @@ pub mod traits;
 
 // re-export commonly used types for convenience
 pub use data::PhysicalData;
-pub use traits::{PhysicalModel, PhysicalQuantity, PhysicalState};
+pub use traits::{
+    ExportError, Exportable, PhysicalModel, PhysicalQuantity, PhysicalState, outlet_data,
+    sample_indices,
+};

--- a/src/physics/traits.rs
+++ b/src/physics/traits.rs
@@ -517,12 +517,15 @@ impl std::ops::Mul<f64> for PhysicalState {
 ///
 /// ```rust
 /// use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
+/// use serde::{Deserialize, Serialize};
 ///
+/// #[derive(Deserialize, Serialize)]
 /// struct SimpleTransport {
 ///     points: usize,
 ///     velocity: f64,
 /// }
 ///
+/// #[typetag::serde]
 /// impl PhysicalModel for SimpleTransport {
 ///     fn points(&self) -> usize {
 ///         self.points
@@ -548,6 +551,7 @@ impl std::ops::Mul<f64> for PhysicalState {
 ///     }
 /// }
 /// ```
+#[typetag::serde]
 pub trait PhysicalModel: Send + Sync {
     /// Number of spatial points
     ///
@@ -556,7 +560,10 @@ pub trait PhysicalModel: Send + Sync {
     /// # Example
     /// ```rust
     /// # use chrom_rs::physics::PhysicalModel;
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[derive(Deserialize, Serialize)]
     /// # struct MyModel { points: usize }
+    /// # #[typetag::serde]
     /// # impl PhysicalModel for MyModel {
     /// #   fn points(&self) -> usize { self.points }
     /// #   fn compute_physics(&self, state: &chrom_rs::physics::PhysicalState) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
@@ -608,8 +615,11 @@ pub trait PhysicalModel: Send + Sync {
     /// # Example
     /// ```rust
     /// use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
+    /// use serde::{Deserialize, Serialize};
     ///
+    /// #[derive(Deserialize, Serialize)]
     /// struct MyModel;
+    /// #[typetag::serde]
     /// impl PhysicalModel for MyModel {
     ///     fn points(&self) -> usize { 100 }
     ///
@@ -650,7 +660,10 @@ pub trait PhysicalModel: Send + Sync {
     /// # Example
     /// ```rust
     /// # use chrom_rs::physics::PhysicalModel;
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[derive(Deserialize, Serialize)]
     /// # struct Transport;
+    /// # #[typetag::serde]
     /// # impl PhysicalModel for Transport {
     /// #   fn points(&self) -> usize { 100 }
     /// #   fn compute_physics(&self, _: &chrom_rs::physics::PhysicalState) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
@@ -670,7 +683,10 @@ pub trait PhysicalModel: Send + Sync {
     /// # Example
     /// ```rust
     /// # use chrom_rs::physics::PhysicalModel;
+    /// # use serde::{Deserialize, Serialize};
+    /// # #[derive(Deserialize, Serialize)]
     /// # struct MyModel;
+    /// # #[typetag::serde]
     /// # impl PhysicalModel for MyModel {
     /// #   fn points(&self) -> usize { 100 }
     /// #   fn compute_physics(&self, _: &chrom_rs::physics::PhysicalState) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }

--- a/src/physics/traits.rs
+++ b/src/physics/traits.rs
@@ -15,6 +15,7 @@
 
 use crate::physics::data::PhysicalData;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 
 // =================================================================================================
@@ -702,6 +703,270 @@ pub trait PhysicalModel: Send + Sync {
     }
 }
 
+// =============================================================================
+// ExportError
+// =============================================================================
+
+/// Errors that can occur during export mapping.
+///
+/// Returned by [`Exportable::from_map`] when the provided map does not
+/// contain the expected keys or holds values of the wrong type.
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::physics::ExportError;
+///
+/// let err = ExportError::MissingKey("metadata".into());
+/// assert_eq!(err.to_string(), "export map: missing key 'metadata'");
+/// ```
+#[derive(Debug)]
+pub enum ExportError {
+    /// A required key is absent from the map.
+    MissingKey(String),
+
+    /// A key is present but its value has an unexpected type or format.
+    InvalidValue { key: String, reason: String },
+
+    /// The number of species in the map does not match the model.
+    SpeciesCountMismatch { expected: usize, got: usize },
+}
+
+impl std::fmt::Display for ExportError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportError::MissingKey(k) => {
+                write!(f, "export map: missing key '{k}'")
+            }
+            ExportError::InvalidValue { key, reason } => {
+                write!(f, "export map: invalid value for '{key}': {reason}")
+            }
+            ExportError::SpeciesCountMismatch { expected, got } => {
+                write!(f, "export map: expected {expected} species, got {got}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ExportError {}
+
+// =============================================================================
+// Exportable trait
+// =============================================================================
+
+/// Opt-in mapping layer between a physical model and a generic JSON map.
+///
+/// # Design
+///
+/// [`Exportable`] is independent of [`PhysicalModel`]. A model that needs
+/// structured JSON output implements this trait; models that do not require
+/// export are unaffected.
+///
+/// The trait defines the **mapping layer** only. File I/O lives in
+/// [`crate::output::export::json`] and operates on the map without any
+/// knowledge of physical models.
+///
+/// The signature of [`to_map`](Exportable::to_map) takes the components of
+/// `SimulationResult` explicitly rather than `&SimulationResult` itself.
+/// This avoids a circular dependency:
+/// `solver` already imports `physics`, so `physics` cannot import `solver`.
+///
+/// # Object safety
+///
+/// [`to_map`](Exportable::to_map) is **object-safe** — callable via
+/// `Box<dyn Exportable>`.
+///
+/// [`from_map`](Exportable::from_map) is **not object-safe** (`Self: Sized`).
+/// It is intended for concrete types only, typically in the CLI layer.
+///
+/// # JSON layout convention (DD-010)
+///
+/// ```json
+/// {
+///   "metadata": {
+///     "solver":    "RK4",
+///     "model":     "LangmuirMulti",
+///     "timestamp": "1744800000"
+///   },
+///   "data": {
+///     "time_points": [0.0, 0.06, "..."],
+///     "profiles": {
+///       "species_0": { "name": "Malic",  "Concentration": ["..."] },
+///       "species_1": { "name": "Citric", "Concentration": ["..."] },
+///       "global":    { "Temperature":    ["..."] }
+///     }
+///   }
+/// }
+/// ```
+///
+/// Dispatch rule driven by [`PhysicalData`] shape:
+/// - `Matrix [n_points × n_species]` → `"species_N"` blocks
+/// - `Scalar` or `Vector [n_points]`  → `"global"` block
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::physics::{Exportable, ExportError, PhysicalState};
+/// use serde_json::{Map, Value};
+/// use std::collections::HashMap;
+///
+/// struct TrivialModel;
+///
+/// impl Exportable for TrivialModel {
+///     fn to_map(
+///         &self,
+///         time_points: &[f64],
+///         _trajectory: &[PhysicalState],
+///         _metadata: &HashMap<String, String>,
+///     ) -> Map<String, Value> {
+///         let mut map = Map::new();
+///         let tp: Vec<Value> = time_points.iter().map(|&t| Value::from(t)).collect();
+///         map.insert("time_points".into(), Value::Array(tp));
+///         map
+///     }
+///
+///     fn from_map(map: Map<String, Value>) -> Result<Self, ExportError>
+///     where
+///         Self: Sized,
+///     {
+///         let _ = map;
+///         Ok(TrivialModel)
+///     }
+/// }
+/// ```
+pub trait Exportable {
+    /// Builds a JSON map from the simulation data.
+    ///
+    /// Receives the three components of `SimulationResult` directly to avoid
+    /// a `physics → solver` circular dependency.
+    ///
+    /// # Arguments
+    ///
+    /// * `time_points` — time grid produced by the solver
+    /// * `trajectory`  — sequence of physical states over time
+    /// * `metadata`    — key/value pairs written by the solver (solver name, dt, …)
+    fn to_map(
+        &self,
+        time_points: &[f64],
+        trajectory: &[PhysicalState],
+        metadata: &HashMap<String, String>,
+    ) -> Map<String, Value>;
+
+    /// Reconstructs a model instance from a previously exported map.
+    ///
+    /// Not object-safe (`Self: Sized`) — call on concrete types only.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExportError`] if required keys are absent or have incompatible
+    /// types.
+    fn from_map(map: Map<String, Value>) -> Result<Self, ExportError>
+    where
+        Self: Sized;
+}
+
+// =============================================================================
+// Shared helpers — available to all Exportable implementors
+// =============================================================================
+
+/// Extracts outlet data for any physical quantity from a trajectory state at index `idx`.
+///
+/// The "outlet" is the last spatial point (column exit), consistent with
+/// the upwind spatial discretisation used by all Langmuir models.
+///
+/// This function is generic over [`PhysicalQuantity`]: pass
+/// `PhysicalQuantity::Concentration` for concentration profiles,
+/// `PhysicalQuantity::Temperature` for temperature profiles, etc.
+/// This allows `to_map` implementations to populate both `"species_N"` blocks
+/// and the `"global"` block without duplicating logic.
+///
+/// | [`PhysicalData`] variant | Return value |
+/// |---|---|
+/// | `Scalar(c)` | `vec![c]` — single global value |
+/// | `Vector(v)` | `vec![v[last]]` — last spatial point |
+/// | `Matrix(m)` | last row of `m`, one entry per species column |
+///
+/// Returns an empty `Vec` when `idx` is out of bounds or the state contains
+/// no entry for the requested quantity.
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::physics::{
+///     outlet_data, PhysicalState, PhysicalQuantity, PhysicalData,
+/// };
+/// use nalgebra::DVector;
+///
+/// let state = PhysicalState::new(
+///     PhysicalQuantity::Concentration,
+///     PhysicalData::Vector(DVector::from_vec(vec![0.0, 0.5, 1.0])),
+/// );
+/// let trajectory = vec![state];
+///
+/// // Concentration at outlet (last spatial point)
+/// let outlet = outlet_data(PhysicalQuantity::Concentration, &trajectory, 0);
+/// assert_eq!(outlet, vec![1.0]);
+///
+/// // Unknown quantity → empty Vec
+/// let empty = outlet_data(PhysicalQuantity::Temperature, &trajectory, 0);
+/// assert!(empty.is_empty());
+/// ```
+pub fn outlet_data(
+    quantity: PhysicalQuantity,
+    trajectory: &[PhysicalState],
+    idx: usize,
+) -> Vec<f64> {
+    let state = match trajectory.get(idx) {
+        Some(s) => s,
+        None => return vec![],
+    };
+
+    match state.get(quantity) {
+        Some(PhysicalData::Scalar(c)) => vec![*c],
+        Some(PhysicalData::Vector(v)) => v.iter().next_back().copied().into_iter().collect(),
+        Some(PhysicalData::Matrix(m)) if m.nrows() > 0 => {
+            let last = m.nrows() - 1;
+            (0..m.ncols()).map(|s| m[(last, s)]).collect()
+        }
+        _ => vec![],
+    }
+}
+
+/// Uniformly samples `n` indices from `0..total`, always including first and last.
+///
+/// Guarantees the trailing edge of a chromatographic peak is never truncated.
+///
+/// | `n` | Behaviour |
+/// |---|---|
+/// | `None` | All indices `0..total` |
+/// | `Some(0)` or `Some(n ≥ total)` | All indices |
+/// | `Some(1)` | `[0]` only |
+/// | `Some(n)` | `n` evenly spaced; last index always `total - 1` |
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::physics::sample_indices;
+///
+/// // Formula: (i * 99) / 4 with integer division → [0, 24, 49, 74, 99]
+/// assert_eq!(sample_indices(100, Some(5)), vec![0, 24, 49, 74, 99]);
+/// assert_eq!(sample_indices(4, None), vec![0, 1, 2, 3]);
+/// ```
+pub fn sample_indices(total: usize, n: Option<usize>) -> Vec<usize> {
+    match n {
+        None | Some(0) => (0..total).collect(),
+        Some(n) if n >= total => (0..total).collect(),
+        Some(1) => vec![0],
+        Some(n) => {
+            let mut indices: Vec<usize> = (0..n).map(|i| (i * (total - 1)) / (n - 1)).collect();
+            if let Some(last) = indices.last_mut() {
+                *last = total - 1;
+            }
+            indices
+        }
+    }
+}
+
 // =================================================================================================
 // Tests
 // =================================================================================================
@@ -1104,5 +1369,76 @@ mod tests {
 
         let temp = scaled.get(PhysicalQuantity::Temperature).unwrap();
         assert_eq!(temp.as_scalar(), 150.0);
+    }
+    // =============================================================================
+    // Exportable helpers — tests
+    // =============================================================================
+
+    #[test]
+    fn test_outlet_data_scalar() {
+        let state = PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Scalar(3.14));
+        assert_eq!(
+            super::outlet_data(PhysicalQuantity::Concentration, &[state], 0),
+            vec![3.14]
+        );
+    }
+
+    #[test]
+    fn test_outlet_data_vector_last_point() {
+        let state = PhysicalState::new(
+            PhysicalQuantity::Concentration,
+            PhysicalData::Vector(nalgebra::DVector::from_vec(vec![0.0, 0.5, 1.0])),
+        );
+        let outlet = super::outlet_data(PhysicalQuantity::Concentration, &[state], 0);
+        assert!((outlet[0] - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_outlet_data_out_of_bounds() {
+        let state = PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Scalar(1.0));
+        assert!(super::outlet_data(PhysicalQuantity::Concentration, &[state], 99).is_empty());
+    }
+
+    #[test]
+    fn test_outlet_data_unknown_quantity() {
+        let state = PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Scalar(1.0));
+        // Temperature not present → empty Vec
+        assert!(super::outlet_data(PhysicalQuantity::Temperature, &[state], 0).is_empty());
+    }
+
+    #[test]
+    fn test_sample_indices_full() {
+        assert_eq!(super::sample_indices(4, None), vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_sample_indices_five_from_hundred() {
+        // Formula: (i * 99) / 4 with integer division → [0, 24, 49, 74, 99]
+        assert_eq!(super::sample_indices(100, Some(5)), vec![0, 24, 49, 74, 99]);
+    }
+
+    #[test]
+    fn test_sample_indices_single() {
+        assert_eq!(super::sample_indices(100, Some(1)), vec![0]);
+    }
+
+    #[test]
+    fn test_sample_indices_larger_than_total() {
+        assert_eq!(super::sample_indices(3, Some(10)), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_export_error_display_missing_key() {
+        let e = super::ExportError::MissingKey("metadata".into());
+        assert_eq!(e.to_string(), "export map: missing key 'metadata'");
+    }
+
+    #[test]
+    fn test_export_error_display_mismatch() {
+        let e = super::ExportError::SpeciesCountMismatch {
+            expected: 2,
+            got: 1,
+        };
+        assert_eq!(e.to_string(), "export map: expected 2 species, got 1");
     }
 }

--- a/src/solver/boundary.rs
+++ b/src/solver/boundary.rs
@@ -11,6 +11,7 @@
 //! This allows arbitrary dimensional problems without artificial limits.
 
 use crate::physics::PhysicalState;
+use serde::{Deserialize, Serialize};
 use std::fmt;
 
 // =================================================================================================
@@ -38,7 +39,7 @@ use std::fmt;
 /// // ODE: temporal only
 /// let boundaries = DomainBoundaries::temporal(initial_state);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DomainBoundaries {
     /// Boundaries for each dimension
     pub dimensions: Vec<DimensionBoundary>,
@@ -343,7 +344,7 @@ impl Default for DomainBoundaries {
 ///
 /// - 1 state: temporal dimension (initial condition)
 /// - 2 states: spatial dimension (left, right boundaries)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DimensionBoundary {
     /// Dimension name
     pub name: String,
@@ -399,7 +400,7 @@ impl DimensionBoundary {
 // =================================================================================================
 
 /// Convention for identifying registration of time variable
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 pub enum TimeAxisConvention {
     /// No time dimension (steady-state)
     None,

--- a/src/solver/methods/euler.rs
+++ b/src/solver/methods/euler.rs
@@ -50,7 +50,10 @@
 //! # use chrom_rs::solver::{EulerSolver, Solver, SolverConfiguration, Scenario, DomainBoundaries};
 //! # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 //! # use nalgebra::DVector;
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -118,7 +121,10 @@ use crate::solver::{Scenario, SimulationResult, Solver, SolverConfiguration, Sol
 /// # use chrom_rs::solver::{EulerSolver, Solver, Scenario, DomainBoundaries, SolverConfiguration};
 /// # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 /// # use nalgebra::DVector;
+/// # use serde::{Deserialize, Serialize};
+/// # #[derive(Deserialize, Serialize)]
 /// # struct MyModel;
+/// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
 /// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -296,6 +302,7 @@ mod tests {
     use super::*;
     use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
     use crate::solver::boundary::DomainBoundaries;
+    use serde::{Deserialize, Serialize};
 
     // ====== Mock Models for Testing ======
 
@@ -304,11 +311,13 @@ mod tests {
     /// Analytical solution: y(t) = y_0 * exp(-k * t)
     ///
     /// This is used to test numerical accuracy since we know the exact solution.
+    #[derive(Deserialize, Serialize)]
     struct ExponentialDecay {
         points: usize,
         decay_rate: f64, // k in dy/dt = -k*y
     }
 
+    #[typetag::serde]
     impl PhysicalModel for ExponentialDecay {
         fn points(&self) -> usize {
             self.points
@@ -342,11 +351,13 @@ mod tests {
     /// Mock model: constant growth dy/dt = c
     ///
     /// Analytical solution: y(t) = y_0 + c * t
+    #[derive(Deserialize, Serialize)]
     struct ConstantGrowth {
         points: usize,
         growth_rate: f64,
     }
 
+    #[typetag::serde]
     impl PhysicalModel for ConstantGrowth {
         fn points(&self) -> usize {
             self.points
@@ -738,10 +749,13 @@ mod tests {
     #[test]
     fn test_euler_detects_nan() {
         // Create a model that produces NaN
+
+        #[derive(Deserialize, Serialize)]
         struct NaNModel {
             points: usize,
         }
 
+        #[typetag::serde]
         impl PhysicalModel for NaNModel {
             fn points(&self) -> usize {
                 self.points
@@ -785,10 +799,12 @@ mod tests {
     #[test]
     fn test_euler_detects_inf() {
         // Create a model that produces Inf
+        #[derive(Deserialize, Serialize)]
         struct InfModel {
             points: usize,
         }
 
+        #[typetag::serde]
         impl PhysicalModel for InfModel {
             fn points(&self) -> usize {
                 self.points
@@ -865,10 +881,12 @@ mod tests {
     fn test_euler_multiple_quantity() {
         // Simulation with two different PhysicalQuantity
 
+        #[derive(Deserialize, Serialize)]
         struct MultiQuantityModel {
             points: usize,
         }
 
+        #[typetag::serde]
         impl PhysicalModel for MultiQuantityModel {
             fn points(&self) -> usize {
                 self.points

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -47,9 +47,12 @@
 //! use chrom_rs::solver::{Scenario, DomainBoundaries, Solver, SolverConfiguration};
 //! use chrom_rs::physics::{ PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData };
 //! use nalgebra::DVector;
+//! use serde::{Deserialize, Serialize};
 //!
+//! #[derive(Deserialize, Serialize)]
 //! struct MyModel;
 //!
+//! #[typetag::serde]
 //! impl PhysicalModel for MyModel {
 //!      fn points(&self) -> usize { 1 }
 //!      fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }

--- a/src/solver/methods/rk4.rs
+++ b/src/solver/methods/rk4.rs
@@ -71,7 +71,10 @@
 //! use chrom_rs::solver::{RK4Solver, Solver, SolverConfiguration, Scenario, DomainBoundaries};
 //! # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 //! # use nalgebra::DVector;
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -150,7 +153,10 @@ use crate::solver::{
 /// # use chrom_rs::solver::{RK4Solver, Solver, SolverConfiguration, Scenario, DomainBoundaries};
 /// # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 /// # use nalgebra::DVector;
+/// # use serde::{Deserialize, Serialize};
+/// # #[derive(Deserialize, Serialize)]
 /// # struct MyModel;
+/// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
 /// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -354,6 +360,7 @@ mod tests {
     use super::*;
     use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
     use crate::solver::boundary::DomainBoundaries;
+    use serde::{Deserialize, Serialize};
 
     // ====== Mock Models for Testing ======
 
@@ -364,11 +371,13 @@ mod tests {
     /// Analytical solution: y(t) = y_0 * exp(-k * t)
     ///
     /// This is used to test numerical accuracy since we know the exact solution.
+    #[derive(Deserialize, Serialize)]
     struct ExponentialDecay {
         points: usize,
         decay_rate: f64, // k in dy/dt = -k*y
     }
 
+    #[typetag::serde]
     impl PhysicalModel for ExponentialDecay {
         fn points(&self) -> usize {
             self.points
@@ -402,11 +411,13 @@ mod tests {
     /// Mock model: constant growth dy/dt = c
     ///
     /// Analytical solution: y(t) = y_0 + c * t
+    #[derive(Deserialize, Serialize)]
     struct ConstantGrowth {
         points: usize,
         growth_rate: f64,
     }
 
+    #[typetag::serde]
     impl PhysicalModel for ConstantGrowth {
         fn points(&self) -> usize {
             self.points
@@ -437,11 +448,13 @@ mod tests {
     /// Rewritten as first-order system:
     ///   dy_1/dt = y_2         (velocity)
     ///   dy_2/dt = -omega^2·y_1     (acceleration)
+    #[derive(Deserialize, Serialize)]
     struct HarmonicOscillator {
         points: usize,
         omega: f64, // Angular frequency
     }
 
+    #[typetag::serde]
     impl PhysicalModel for HarmonicOscillator {
         fn points(&self) -> usize {
             self.points
@@ -823,10 +836,12 @@ mod tests {
 
     #[test]
     fn test_rk4_detects_nan() {
+        #[derive(Deserialize, Serialize)]
         struct NaNModel {
             points: usize,
         }
 
+        #[typetag::serde]
         impl PhysicalModel for NaNModel {
             fn points(&self) -> usize {
                 self.points
@@ -867,10 +882,12 @@ mod tests {
 
     #[test]
     fn test_rk4_detects_inf() {
+        #[derive(Deserialize, Serialize)]
         struct InfModel {
             points: usize,
         }
 
+        #[typetag::serde]
         impl PhysicalModel for InfModel {
             fn points(&self) -> usize {
                 self.points
@@ -941,10 +958,12 @@ mod tests {
 
     #[test]
     fn test_rk4_multi_quantity() {
+        #[derive(Deserialize, Serialize)]
         struct MultiQuantityModel {
             points: usize,
         }
 
+        #[typetag::serde]
         impl PhysicalModel for MultiQuantityModel {
             fn points(&self) -> usize {
                 self.points

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -57,7 +57,10 @@
 //! ```rust
 //! # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 //! # use chrom_rs::solver::{Scenario, DomainBoundaries, SolverConfiguration, Solver, EulerSolver};
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -162,7 +165,10 @@
 //! # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 //! # use chrom_rs::solver::{Scenario, DomainBoundaries};
 //! # use nalgebra::DVector;
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -307,7 +313,10 @@
 //! ```rust
 //! # use chrom_rs::solver::{Solver, EulerSolver, Scenario, DomainBoundaries, SolverConfiguration};
 //! # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
+//! # use serde::{Deserialize, Serialize};
+//! # #[derive(Deserialize, Serialize)]
 //! # struct MyModel;
+//! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
 //! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -21,7 +21,10 @@ use crate::solver::boundary::DomainBoundaries;
 /// # use chrom_rs::solver::{Scenario, DomainBoundaries, EulerSolver, Solver, SolverConfiguration};
 /// # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 /// # use nalgebra::DVector;
+/// # use serde::{Deserialize, Serialize};
+/// # #[derive(Deserialize, Serialize)]
 /// # struct MyModel;
+/// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
 /// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
@@ -104,8 +107,10 @@ mod tests {
     use super::*;
     use crate::physics::traits::{PhysicalModel, PhysicalState};
     use crate::solver::boundary::{DimensionBoundary, DomainBoundaries, TimeAxisConvention};
+    use serde::{Deserialize, Serialize};
 
     // Mocking a Physical model
+    #[derive(Deserialize, Serialize)]
     struct MockModel {
         content: Vec<PhysicalState>,
         model_name: String,
@@ -120,6 +125,7 @@ mod tests {
         }
     }
 
+    #[typetag::serde]
     impl PhysicalModel for MockModel {
         fn points(&self) -> usize {
             10

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -3,6 +3,7 @@
 //! A scenario combines a physical model with boundary conditions.
 use crate::physics::traits::PhysicalModel;
 use crate::solver::boundary::DomainBoundaries;
+use serde::{Deserialize, Serialize};
 
 /// Simulation scenario
 ///
@@ -46,6 +47,7 @@ use crate::solver::boundary::DomainBoundaries;
 /// # Ok(())
 /// # }
 /// ```
+#[derive(Deserialize, Serialize)]
 pub struct Scenario {
     /// Physical model (equations)
     pub model: Box<dyn PhysicalModel>,

--- a/src/solver/traits.rs
+++ b/src/solver/traits.rs
@@ -16,6 +16,7 @@
 
 use crate::physics::traits::PhysicalState;
 use crate::solver::scenario::Scenario;
+use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, string::ToString};
 
 // ============================================================================
@@ -58,7 +59,7 @@ use std::{collections::HashMap, string::ToString};
 /// };
 /// ```
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub enum SolverType {
     /// Time evolution solution (ODE/PDE integration)
     ///
@@ -254,7 +255,7 @@ impl SolverType {
 ///     }
 /// );
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SolverConfiguration {
     /// Type of solver and its paraméters
     pub solver_type: SolverType,
@@ -403,7 +404,7 @@ impl SolverConfiguration {
 ///     final_state,
 /// );
 /// ```
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SimulationResult {
     // Time points at which the solution was computed
     ///

--- a/src/solver/traits.rs
+++ b/src/solver/traits.rs
@@ -535,7 +535,10 @@ impl SimulationResult {
 /// use chrom_rs::solver::{Solver, SolverConfiguration, Scenario, DomainBoundaries, RK4Solver};
 /// # use chrom_rs::physics::{PhysicalModel, PhysicalState, PhysicalQuantity, PhysicalData};
 /// # use nalgebra::DVector;
+/// # use serde::{Deserialize, Serialize};
+/// # #[derive(Deserialize, Serialize)]
 /// # struct MyModel;
+/// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
 /// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }

--- a/tests/common/mock_models.rs
+++ b/tests/common/mock_models.rs
@@ -32,6 +32,7 @@ impl ExponentialDecay {
     }
 }
 
+#[typetag::serde]
 impl PhysicalModel for ExponentialDecay {
     fn points(&self) -> usize {
         self.points
@@ -89,6 +90,7 @@ impl ConstantGrowth {
     }
 }
 
+#[typetag::serde]
 impl PhysicalModel for ConstantGrowth {
     fn points(&self) -> usize {
         self.points
@@ -121,6 +123,7 @@ impl PhysicalModel for ConstantGrowth {
 /// Linear transport model (simplified)
 ///
 /// This is a placeholder for more complex transport models.
+#[derive(Serialize, Deserialize)]
 pub struct LinearTransport {
     pub points: usize,
     pub velocity: f64,
@@ -132,6 +135,7 @@ impl LinearTransport {
     }
 }
 
+#[typetag::serde]
 impl PhysicalModel for LinearTransport {
     fn points(&self) -> usize {
         self.points


### PR DESCRIPTION
## Summary

Completes the Application Layer foundation for v0.2.0.

### DD-009 — Serialisation format (#14)
- `serde` + `typetag` + `nalgebra/serde-serialize` on all core types
- `Scenario`, `SolverConfiguration`, `SimulationResult` fully serializable

### DD-010 — JSON output (#15)
- `Exportable` trait in `physics/traits.rs` (option A — no circular dependency)
- `outlet_data`, `sample_indices` shared helpers
- `LangmuirSingle` and `LangmuirMulti` implement `Exportable`
- `output/export/json.rs`: `to_json` / `from_json` — pure I/O layer
- `serde_json = "1.0"` added

### Quality
- `cargo test` ✅
- `cargo test --doc` ✅
- `cargo clippy` ✅
- `cargo fmt` ✅

Closes #14, Closes #15