### PR TITLE
feat(v0.2.0): Application Layer — CLI, config loaders, examples, tests, rustdoc

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -112,10 +112,10 @@ component_management:
     # CSV : Export des résultats au format CSV
     # Décommenter quand le module sera implémenté
     # --------------------------------------------------------------------------
-    - component_id: csv
-      name: "CSV Export"
+    - component_id: export
+      name: "Export"
       paths:
-        - src/output/csv/**
+        - src/output/export/**
       statuses:
         - type: project
           target: 75%

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Versioning: [SemVer](https://semver.org/)
 - `Exportable` implemented on `LangmuirSingle` and `LangmuirMulti` — named species blocks (`species_N` + `"name"` key), `global` extension point for scalar/vector quantities
 - `output/export/json.rs`: `to_json` / `from_json` — pure I/O layer, `Map<String, Value>` only, no model knowledge
 - `serde_json = "1.0"` added to dependencies
+- `step: Option<usize>` field on `SolverConfiguration` with `#[serde(default)]` — trajectory subsampling for JSON export (DD-010 / DD-015); builder `with_step(n) -> Self`
+- `set_injection(&mut self, TemporalInjection)` on `LangmuirSingle` — replaces injection profile post-deserialisation
+- `set_injection_all(&mut self, TemporalInjection)` and `set_injection_for(&mut self, &str, TemporalInjection) -> Result<(), String>` on `LangmuirMulti`
+- `PhysicalModel::set_injections(&mut self, &HashMap<Option<String>, TemporalInjection>) -> Result<(), String>` — single generic injection entry-point on the trait: `None` key = default for all unlisted species, `Some(name)` key = per-species override; default no-op for models without injection
+- `config/` module (DD-015): `ConfigError` (Io / UnsupportedFormat / Parse / Validation), `Format` enum, `load_from_file<T>` generic helper (format check precedes file I/O)
+- `config/model.rs`: `load_model(path) -> Result<Box<dyn PhysicalModel>, ConfigError>` via typetag — injection left as `None`, applied by scenario loader
+- `config/scenario.rs`: `load_scenario(path, &mut dyn PhysicalModel) -> Result<DomainBoundaries, ConfigError>` — builds `HashMap<Option<String>, TemporalInjection>` from `default_injection` and `injections[]` YAML fields, calls `set_injections` once; `initial_condition: zero` supported in v0.2.0
+- `config/solver.rs`: `load_solver(path) -> Result<SolverConfig, ConfigError>` — `SolverConfig { config: SolverConfiguration, solver_name: String }`; validates `type` (RK4 / Euler), `total_time > 0`, `time_steps > 0`
 
 ### Changed
 - Upgrade `dynamic-cli` dependency from `0.1.1` to `0.2.0`
@@ -33,10 +41,9 @@ Versioning: [SemVer](https://semver.org/)
 - Fix rustdoc redirect in CI: `dynamic_cli/index.html` → `chrom_rs/index.html`
 - Enable and fix all doc-tests across `models/`, `solver/`, and `output/` modules — remove `ignore` attribute, align examples with current public API
 - Add `libfontconfig1-dev` system dependency in CI jobs (required by `plotters`)
-- `LangmuirMulti`: add public accessors `porosity`, `velocity`, `column_length`, `spatial_points`, `species_params`
-
-### Removed
-- Untrack `langmuir_single_simple.rs` (out of scope, kept locally)
+- `LangmuirMulti`: add public accessors `porosity`, `velocity`, `column_length`, `spatial_points`, `species_params` — with full rustdoc (physical symbol, unit, relation to precomputed quantities)
+- `LangmuirMulti` `PhysicalModel` impl methods (`points`, `name`, `description`) documented
+- `LangmuirSingle` and `LangmuirMulti`: Exportable `to_map` / `from_map` round-trip tests added (closes #34)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Versioning: [SemVer](https://semver.org/)
 - `config/model.rs`: `load_model(path) -> Result<Box<dyn PhysicalModel>, ConfigError>` via typetag — injection left as `None`, applied by scenario loader
 - `config/scenario.rs`: `load_scenario(path, &mut dyn PhysicalModel) -> Result<DomainBoundaries, ConfigError>` — builds `HashMap<Option<String>, TemporalInjection>` from `default_injection` and `injections[]` YAML fields, calls `set_injections` once; `initial_condition: zero` supported in v0.2.0
 - `config/solver.rs`: `load_solver(path) -> Result<SolverConfig, ConfigError>` — `SolverConfig { config: SolverConfiguration, solver_name: String }`; validates `type` (RK4 / Euler), `total_time > 0`, `time_steps > 0`
+- `cli/` module (DD-001, #32): command-line interface via `dynamic-cli 0.2.0`
+  - `src/cli/commands.yml` — declarative command configuration, embedded at compile time via `include_str!`
+  - `src/cli/app.rs` — `ChromContext` (execution context with validated `--project-dir`), `ContextError`, `RunHandler`, `resolve_species_names`, `resolve_export_map`; `to_cli_err` bridges `anyhow::Error` to `ExecutionError::CommandFailed`
+  - `src/cli/mod.rs` — `build_app()` entry point; `load_yaml(COMMANDS_YML)` + `CliBuilder`
+  - Command surface: `chrom-rs run --model --scenario --solver [--project-dir] [--output-csv] [--output-plot] [--export-json]`
+  - `--project-dir` validation: rejects `..` components, checks read/write permissions via probe file
+  - Single/multi-species dispatch via root-key detection at load time — no modification of `PhysicalModel` trait
+- `src/main.rs` — delegates to `cli::build_app()` + `app.run()`, exits with code 1 on error
 
 ### Changed
 - Upgrade `dynamic-cli` dependency from `0.1.1` to `0.2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,14 +33,25 @@ Versioning: [SemVer](https://semver.org/)
 - `config/model.rs`: `load_model(path) -> Result<Box<dyn PhysicalModel>, ConfigError>` via typetag — injection left as `None`, applied by scenario loader
 - `config/scenario.rs`: `load_scenario(path, &mut dyn PhysicalModel) -> Result<DomainBoundaries, ConfigError>` — builds `HashMap<Option<String>, TemporalInjection>` from `default_injection` and `injections[]` YAML fields, calls `set_injections` once; `initial_condition: zero` supported in v0.2.0
 - `config/solver.rs`: `load_solver(path) -> Result<SolverConfig, ConfigError>` — `SolverConfig { config: SolverConfiguration, solver_name: String }`; validates `type` (RK4 / Euler), `total_time > 0`, `time_steps > 0`
-- `cli/` module (DD-001, #32): command-line interface via `dynamic-cli 0.2.0`
-  - `src/cli/commands.yml` — declarative command configuration, embedded at compile time via `include_str!`
-  - `src/cli/app.rs` — `ChromContext` (execution context with validated `--project-dir`), `ContextError`, `RunHandler`, `resolve_species_names`, `resolve_export_map`; `to_cli_err` bridges `anyhow::Error` to `ExecutionError::CommandFailed`
-  - `src/cli/mod.rs` — `build_app()` entry point; `load_yaml(COMMANDS_YML)` + `CliBuilder`
-  - Command surface: `chrom-rs run --model --scenario --solver [--project-dir] [--output-csv] [--output-plot] [--export-json]`
-  - `--project-dir` validation: rejects `..` components, checks read/write permissions via probe file
-  - Single/multi-species dispatch via root-key detection at load time — no modification of `PhysicalModel` trait
-- `src/main.rs` — delegates to `cli::build_app()` + `app.run()`, exits with code 1 on error
+
+- `examples/tfa_from_config.rs` — reproduces `tfa.rs` via config files; results
+  numerically identical to direct-API variant (DD-015 validation)
+- `examples/acids_from_config.rs` — reproduces `acids_multi.rs` via config files;
+  solo phase derives `LangmuirSingle` instances from `LangmuirMulti` parameters in
+  `model.yml` — no per-species model file needed
+- `examples/config/tfa/` — `model.yml`, `scenario_dirac.yml`, `scenario_gaussian.yml`,
+  `solver_rk4.yml`, `solver_euler.yml`
+- `examples/config/acids/` — `model.yml`, `scenario_gaussian.yml`, `solver_rk4.yml`,
+  `solver_euler.yml`
+- `tests/cli_integration.rs` — end-to-end integration tests for `RunHandler::execute`
+  using `examples/config/` fixtures; covers `read_model_file`, `peek_root_key`,
+  `deserialise_inner`, `resolve_species_names`, `resolve_export_map`, CSV/plot/JSON
+  dispatch for both single-species (TFA) and multi-species (acids competitive) cases
+
+### Fixed
+- `cli/app.rs`: use `model.points()` (spatial points) instead of
+  `result.time_points.len()` in `plot_chromatogram` / `plot_chromatogram_multi` —
+  prevents matrix index out of bounds when trajectory length ≠ spatial grid size
 
 ### Changed
 - Upgrade `dynamic-cli` dependency from `0.1.1` to `0.2.0`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,16 @@ name = "tfa_single"
 path = "examples/tfa.rs"
 
 [[example]]
+name = "tfa_from_config"
+path = "examples/tfa_from_config.rs"
+
+[[example]]
 name = "acids_multi"
 path = "examples/acids_multi.rs"
+
+[[example]]
+name = "acids_from_config"
+path = "examples/acids_from_config.rs"
 
 [[example]]
 name = "high_load"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ ndarray = { version = "0.17.2", features = ["serde"] }
 
 [dev-dependencies]
 approx = "0.5.1"
-cargo-llvm-cov = "0.7.1"
+cargo-llvm-cov = "0.8.5"
 criterion = { version = "0.8", features = ["html_reports", "plotters"] }
 tempfile = "3.25.0"
 rand = "0.10"

--- a/examples/acids_from_config.rs
+++ b/examples/acids_from_config.rs
@@ -1,0 +1,495 @@
+//! Example: Ascorbic / Erythorbic Acid — config-file variant
+//!
+//! Reproduces [`acids_multi`](acids_multi.rs) using the three-file configuration
+//! layout defined in DD-015. The physical parameters and simulation results are
+//! numerically identical to the direct-API variant; only the setup differs.
+//!
+//! The solo phase (Phase 1) derives its `LangmuirSingle` instances from
+//! the shared `model.yml` (LangmuirMulti) — no per-species model file needed.
+//!
+//! ## Configuration files used
+//!
+//! ```text
+//! examples/config/acids/
+//! ├── model.yml             ← LangmuirMulti — parameters for all species
+//! ├── scenario_gaussian.yml ← Gaussian injection shared by all phases
+//! ├── solver_rk4.yml        ← RK4,   1200 s, 20 000 steps
+//! └── solver_euler.yml      ← Euler, 1200 s, 20 000 steps
+//! ```
+//!
+//! ## How to run
+//!
+//! ```bash
+//! cargo run --example acids_from_config
+//! ```
+
+use chrom_rs::{
+    config::{model::load_model, scenario::load_scenario, solver::load_solver},
+    models::{LangmuirMulti, LangmuirSingle, TemporalInjection},
+    output::export::{CsvExporter, Exporter},
+    output::{
+        PlotConfig, plot_chromatogram, plot_chromatogram_multi, plot_chromatograms_comparison,
+    },
+    physics::{PhysicalData, PhysicalModel, PhysicalQuantity},
+    solver::{EulerSolver, RK4Solver, Scenario, SimulationResult, Solver},
+};
+
+use std::time::Instant;
+
+// ── Config file paths ─────────────────────────────────────────────────────────
+
+const MODEL_MULTI: &str = "examples/config/acids/model.yml";
+const SCENARIO: &str = "examples/config/acids/scenario_gaussian.yml";
+const SOLVER_RK4: &str = "examples/config/acids/solver_rk4.yml";
+const SOLVER_EULER: &str = "examples/config/acids/solver_euler.yml";
+
+// ── Data structures ───────────────────────────────────────────────────────────
+
+struct SoloRun {
+    species_name: String,
+    solver_name: &'static str,
+    elapsed_secs: f64,
+    peak_concentration: f64,
+    retention_time_secs: f64,
+    final_concentration: f64,
+    result: SimulationResult,
+}
+
+struct MultiRun {
+    solver_name: &'static str,
+    elapsed_secs: f64,
+    peak_concentrations: Vec<f64>,
+    retention_times: Vec<f64>,
+    result: SimulationResult,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn print_section(title: &str) {
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("  {title}");
+    println!("═══════════════════════════════════════════════════════\n");
+}
+
+fn outlet_single(result: &SimulationResult, n_points: usize) -> Vec<f64> {
+    result
+        .state_trajectory
+        .iter()
+        .map(
+            |state| match state.get(PhysicalQuantity::Concentration).unwrap() {
+                PhysicalData::Vector(v) => v[n_points - 1],
+                _ => 0.0,
+            },
+        )
+        .collect()
+}
+
+fn outlet_multi(result: &SimulationResult, n_points: usize, n_species: usize) -> Vec<Vec<f64>> {
+    let mut per_species: Vec<Vec<f64>> = vec![Vec::new(); n_species];
+    for state in &result.state_trajectory {
+        if let Some(PhysicalData::Matrix(m)) = state.get(PhysicalQuantity::Concentration) {
+            for s in 0..n_species {
+                per_species[s].push(m[(n_points - 1, s)]);
+            }
+        }
+    }
+    per_species
+}
+
+fn peak_stats(outlet: &[f64], time_points: &[f64]) -> (f64, f64, f64) {
+    let peak = outlet.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    let idx = outlet
+        .iter()
+        .position(|&c| (c - peak).abs() < 1e-12)
+        .unwrap_or(0);
+    let rt = time_points[idx];
+    let final_c = *outlet.last().unwrap_or(&0.0);
+    (peak, rt, final_c)
+}
+
+/// Deserialises model.yml into a concrete `LangmuirMulti` to access species
+/// parameters and column geometry for the solo phase and the header display.
+fn load_multi_model(path: &str) -> Result<LangmuirMulti, Box<dyn std::error::Error>> {
+    let content = std::fs::read_to_string(path)?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&content)?;
+    let inner = value
+        .get("LangmuirMulti")
+        .ok_or("missing 'LangmuirMulti' key in model file")?
+        .clone();
+    let model: LangmuirMulti = serde_yaml::from_value(inner)?;
+    Ok(model)
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    print_section("Ascorbic / Erythorbic Acid — config-file variant (DD-015)");
+
+    // ── Read model parameters for display and solo phase construction ─────────
+    let multi_params = load_multi_model(MODEL_MULTI)?;
+    let n_points = multi_params.spatial_points();
+    let porosity = multi_params.porosity();
+    let velocity = multi_params.velocity();
+    let col_len = multi_params.column_length();
+    let species = multi_params.species_params();
+    let n_species = species.len();
+    let species_names: Vec<&str> = multi_params.species_names();
+
+    // Read solver config for display (use RK4 as reference)
+    let solver_cfg_ref = load_solver(SOLVER_RK4)?;
+    let total_time = match solver_cfg_ref.config.solver_type {
+        chrom_rs::solver::SolverType::TimeEvolution {
+            total_time,
+            time_steps: _,
+        } => total_time,
+        _ => 1200.0,
+    };
+    let time_steps = match solver_cfg_ref.config.solver_type {
+        chrom_rs::solver::SolverType::TimeEvolution {
+            total_time: _,
+            time_steps,
+        } => time_steps,
+        _ => 20_000,
+    };
+
+    // ── Header ────────────────────────────────────────────────────────────────
+    println!("Species:");
+    for sp in species {
+        println!(
+            "  {:<12} λ={}  K̃={} L/mol  N={}",
+            sp.name, sp.lambda, sp.langmuir_k, sp.port_number
+        );
+    }
+    println!("\nColumn:");
+    println!("  ε={porosity}  u={velocity} m/s  L={col_len} m  nz={n_points}");
+    println!("\nSimulation:");
+    println!("  Total time : {total_time} s ({} min)", total_time / 60.0);
+    println!("  Time steps : {time_steps}");
+    println!("  dt         : {:.6} s", total_time / time_steps as f64);
+    println!("\nInjection: Gaussian — center=10 s  σ=3 s  peak=0.1 mol/L");
+
+    let tmp_dir = std::env::temp_dir();
+    let exporter = CsvExporter::default();
+
+    let solver_defs: Vec<(&'static str, &'static str, Box<dyn Solver>)> = vec![
+        ("Euler", SOLVER_EULER, Box::new(EulerSolver::new())),
+        ("Runge-Kutta", SOLVER_RK4, Box::new(RK4Solver::new())),
+    ];
+
+    // =========================================================================
+    // Phase 1 — Solo (LangmuirSingle derived from model.yml, 2 species × 2 solvers)
+    // =========================================================================
+
+    print_section("Phase 1 — Solo Runs: 2 Species × 2 Solvers");
+
+    let mut solo_runs: Vec<SoloRun> = Vec::new();
+
+    for sp in species {
+        for (solver_name, solver_path, solver) in &solver_defs {
+            print!("  {} × {solver_name} … ", sp.name);
+            std::io::Write::flush(&mut std::io::stdout())?;
+
+            let t0 = Instant::now();
+
+            // Build LangmuirSingle from species params + shared column geometry
+            let mut model: Box<dyn PhysicalModel> = Box::new(LangmuirSingle::new(
+                sp.lambda,
+                sp.langmuir_k,
+                sp.port_number as f64,
+                porosity,
+                velocity,
+                col_len,
+                n_points,
+                TemporalInjection::none(),
+            ));
+
+            // Apply injection from scenario file
+            let boundaries = load_scenario(SCENARIO, &mut *model)?;
+            let solver_cfg = load_solver(solver_path)?;
+            let scenario = Scenario::new(model, boundaries);
+
+            let result = match solver_cfg.solver_name.as_str() {
+                "RK4" => RK4Solver::new().solve(&scenario, &solver_cfg.config)?,
+                "Euler" => EulerSolver::new().solve(&scenario, &solver_cfg.config)?,
+                other => return Err(format!("unknown solver '{other}'").into()),
+            };
+
+            let elapsed_secs = t0.elapsed().as_secs_f64();
+            let outlet = outlet_single(&result, n_points);
+            let (peak, rt, final_c) = peak_stats(&outlet, &result.time_points);
+
+            println!("✓ {elapsed_secs:.2} s");
+
+            let png = tmp_dir.join(format!("acids_config_solo_{}_{solver_name}.png", sp.name));
+            let cfg = PlotConfig::chromatogram(format!("{} — {solver_name}", sp.name));
+            plot_chromatogram(&result, n_points, png.to_str().unwrap(), Some(&cfg))?;
+            println!("    plot → {png:?}");
+
+            let csv = tmp_dir.join(format!("acids_config_solo_{}_{solver_name}.csv", sp.name));
+            exporter.export_single(&result, None, csv.to_str().unwrap())?;
+            println!("    csv  → {csv:?}");
+
+            solo_runs.push(SoloRun {
+                species_name: sp.name.clone(),
+                solver_name,
+                elapsed_secs,
+                peak_concentration: peak,
+                retention_time_secs: rt,
+                final_concentration: final_c,
+                result,
+            });
+        }
+    }
+
+    // Comparison plots — one per solver
+    for &(solver_name, _, _) in &solver_defs {
+        let datasets: Vec<(&str, &SimulationResult, usize)> = solo_runs
+            .iter()
+            .filter(|r| r.solver_name == solver_name)
+            .map(|r| (r.species_name.as_str(), &r.result, n_points))
+            .collect();
+
+        let cmp = tmp_dir.join(format!("acids_config_solo_comparison_{solver_name}.png"));
+        let cfg = PlotConfig::chromatogram(format!("Ascorbic / Erythorbic — Solo, {solver_name}"));
+        plot_chromatograms_comparison(datasets, cmp.to_str().unwrap(), Some(&cfg))?;
+        println!("\n  Comparison ({solver_name}) → {cmp:?}");
+    }
+
+    // =========================================================================
+    // Phase 2 — Competitive (LangmuirMulti, 2 solvers)
+    // =========================================================================
+
+    print_section("Phase 2 — Competitive Runs: LangmuirMulti × 2 Solvers");
+
+    let mut multi_runs: Vec<MultiRun> = Vec::new();
+
+    for &(solver_name, solver_path, ref solver) in &solver_defs {
+        print!("  Competitive × {solver_name} … ");
+        std::io::Write::flush(&mut std::io::stdout())?;
+
+        let t0 = Instant::now();
+
+        let mut model = load_model(MODEL_MULTI)?;
+        let boundaries = load_scenario(SCENARIO, &mut *model)?;
+        let solver_cfg = load_solver(solver_path)?;
+        let scenario = Scenario::new(model, boundaries);
+
+        let result = solver.solve(&scenario, &solver_cfg.config)?;
+        let elapsed_secs = t0.elapsed().as_secs_f64();
+        let per_species = outlet_multi(&result, n_points, n_species);
+
+        let mut peak_concentrations = Vec::with_capacity(n_species);
+        let mut retention_times = Vec::with_capacity(n_species);
+        for s in 0..n_species {
+            let (peak, rt, _) = peak_stats(&per_species[s], &result.time_points);
+            peak_concentrations.push(peak);
+            retention_times.push(rt);
+        }
+
+        println!("✓ {elapsed_secs:.2} s");
+
+        let png = tmp_dir.join(format!("acids_config_multi_{solver_name}.png"));
+        let cfg = PlotConfig::chromatogram(format!(
+            "Ascorbic / Erythorbic — Competitive, {solver_name}"
+        ));
+        plot_chromatogram_multi(
+            &result,
+            n_points,
+            &species_names,
+            png.to_str().unwrap(),
+            Some(&cfg),
+        )?;
+        println!("    plot → {png:?}");
+
+        let csv = tmp_dir.join(format!("acids_config_multi_{solver_name}.csv"));
+        exporter.export_multi(&result, None, &species_names, csv.to_str().unwrap())?;
+        println!("    csv  → {csv:?}");
+
+        multi_runs.push(MultiRun {
+            solver_name,
+            elapsed_secs,
+            peak_concentrations,
+            retention_times,
+            result,
+        });
+    }
+
+    // =========================================================================
+    // Phase 3 — Analysis
+    // =========================================================================
+
+    print_section("Results — Solo: Peak Characteristics");
+
+    println!(
+        "{:<12} {:<14} {:>12} {:>12} {:>12}",
+        "Species", "Solver", "Peak (mol/L)", "Ret.Time (s)", "Final (mol/L)"
+    );
+    println!("{:-<65}", "");
+    for r in &solo_runs {
+        println!(
+            "{:<12} {:<14} {:>12.6} {:>12.1} {:>12.6}",
+            r.species_name,
+            r.solver_name,
+            r.peak_concentration,
+            r.retention_time_secs,
+            r.final_concentration
+        );
+    }
+
+    print_section("Results — Competitive: Peak Characteristics");
+
+    println!(
+        "{:<12} {:<14} {:>12} {:>12}",
+        "Species", "Solver", "Peak (mol/L)", "Ret.Time (s)"
+    );
+    println!("{:-<55}", "");
+    for r in &multi_runs {
+        for s in 0..n_species {
+            println!(
+                "{:<12} {:<14} {:>12.6} {:>12.1}",
+                species_names[s], r.solver_name, r.peak_concentrations[s], r.retention_times[s]
+            );
+        }
+        println!("{:-<55}", "");
+    }
+
+    print_section("Performance Comparison");
+
+    println!("{:<18} {:<14} {:>10}", "Phase", "Solver", "Time (s)");
+    println!("{:-<45}", "");
+    for r in &solo_runs {
+        println!(
+            "{:<18} {:<14} {:>10.3}",
+            format!("Solo-{}", r.species_name),
+            r.solver_name,
+            r.elapsed_secs
+        );
+    }
+    for r in &multi_runs {
+        println!(
+            "{:<18} {:<14} {:>10.3}",
+            "Competitive", r.solver_name, r.elapsed_secs
+        );
+    }
+    if multi_runs.len() >= 2 {
+        println!(
+            "\nRK4/Euler ratio (competitive): {:.2}× slower (expected ~4×)",
+            multi_runs[1].elapsed_secs / multi_runs[0].elapsed_secs
+        );
+    }
+
+    print_section("Accuracy: Euler vs RK4");
+
+    println!("— Solo —");
+    for species_name in &species_names {
+        let euler = solo_runs
+            .iter()
+            .find(|r| r.species_name == *species_name && r.solver_name == "Euler")
+            .unwrap();
+        let rk4 = solo_runs
+            .iter()
+            .find(|r| r.species_name == *species_name && r.solver_name == "Runge-Kutta")
+            .unwrap();
+
+        let peak_diff = (rk4.peak_concentration - euler.peak_concentration).abs();
+        let peak_pct = peak_diff / euler.peak_concentration * 100.0;
+        let rt_diff = (rk4.retention_time_secs - euler.retention_time_secs).abs();
+        let rt_ppm = rt_diff / euler.retention_time_secs * 1_000_000.0;
+
+        println!("\n  {species_name}:");
+        println!("    Peak difference     : {peak_diff:.6} mol/L ({peak_pct:.2}%)");
+        println!("    Ret. time difference: {rt_diff:.4} s ({rt_ppm:.2} ppm)");
+    }
+
+    if multi_runs.len() >= 2 {
+        println!("\n— Competitive —");
+        let euler = &multi_runs[0];
+        let rk4 = &multi_runs[1];
+        for s in 0..n_species {
+            let peak_diff = (rk4.peak_concentrations[s] - euler.peak_concentrations[s]).abs();
+            let peak_pct = peak_diff / euler.peak_concentrations[s] * 100.0;
+            let rt_diff = (rk4.retention_times[s] - euler.retention_times[s]).abs();
+            let rt_ppm = rt_diff / euler.retention_times[s] * 1_000_000.0;
+            println!("\n  {} (competitive):", species_names[s]);
+            println!("    Peak difference     : {peak_diff:.6} mol/L ({peak_pct:.2}%)");
+            println!("    Ret. time difference: {rt_diff:.4} s ({rt_ppm:.2} ppm)");
+        }
+    }
+
+    print_section("Peak Validation");
+
+    println!("— Solo —");
+    for r in &solo_runs {
+        let is_peak =
+            r.peak_concentration > 1e-4 && r.final_concentration < r.peak_concentration * 0.1;
+        let status = if is_peak {
+            "✅ PEAK"
+        } else {
+            "❌ PLATEAU / INCOMPLETE"
+        };
+        println!("  {:<12} {:<14} : {status}", r.species_name, r.solver_name);
+    }
+
+    println!("\n— Competitive —");
+    for r in &multi_runs {
+        let per_sp = outlet_multi(&r.result, n_points, n_species);
+        for s in 0..n_species {
+            let peak = r.peak_concentrations[s];
+            let final_c = *per_sp[s].last().unwrap_or(&0.0);
+            let is_peak = peak > 1e-4 && final_c < peak * 0.1;
+            let status = if is_peak {
+                "✅ PEAK"
+            } else {
+                "❌ PLATEAU / INCOMPLETE"
+            };
+            println!(
+                "  {:<12} {:<14} : {status}",
+                species_names[s], r.solver_name
+            );
+        }
+    }
+
+    print_section("Competition Effect — Retention Time Shift (Euler)");
+
+    let euler_multi = multi_runs
+        .iter()
+        .find(|r| r.solver_name == "Euler")
+        .unwrap();
+
+    println!(
+        "{:<12} {:>12} {:>12} {:>12}",
+        "Species", "Solo (s)", "Mixed (s)", "Shift (s)"
+    );
+    println!("{:-<50}", "");
+    for s in 0..n_species {
+        let solo_euler = solo_runs
+            .iter()
+            .find(|r| r.species_name == species_names[s] && r.solver_name == "Euler")
+            .unwrap();
+        let shift = euler_multi.retention_times[s] - solo_euler.retention_time_secs;
+        println!(
+            "{:<12} {:>12.1} {:>12.1} {:>+12.1}",
+            species_names[s], solo_euler.retention_time_secs, euler_multi.retention_times[s], shift
+        );
+    }
+
+    println!();
+    for s in 0..n_species {
+        let solo_euler = solo_runs
+            .iter()
+            .find(|r| r.species_name == species_names[s] && r.solver_name == "Euler")
+            .unwrap();
+        let shift = euler_multi.retention_times[s] - solo_euler.retention_time_secs;
+        let effect = match shift {
+            sh if sh.abs() < 1.0 => {
+                "no significant shift (competition negligible at these concentrations)"
+            }
+            sh if sh > 0.0 => "elutes LATER in mixture (competitor occupies shared sites)",
+            _ => "elutes EARLIER in mixture (displaced by stronger competitor)",
+        };
+        println!("  {} : {effect}", species_names[s]);
+    }
+
+    println!("\nDone.");
+    Ok(())
+}

--- a/examples/acids_from_config.rs
+++ b/examples/acids_from_config.rs
@@ -185,7 +185,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut solo_runs: Vec<SoloRun> = Vec::new();
 
     for sp in species {
-        for (solver_name, solver_path, solver) in &solver_defs {
+        for (solver_name, solver_path, _solver) in &solver_defs {
             print!("  {} × {solver_name} … ", sp.name);
             std::io::Write::flush(&mut std::io::stdout())?;
 

--- a/examples/config/acids/model.yml
+++ b/examples/config/acids/model.yml
@@ -1,0 +1,22 @@
+LangmuirMulti:
+  species:
+    - name: Ascorbic
+      lambda: 1.0
+      langmuir_k: 1.1
+      port_number: 2
+      injection:
+        type: None
+    - name: Erythorbic
+      lambda: 1.0
+      langmuir_k: 1.7
+      port_number: 2
+      injection:
+        type: None
+  n_points: 100
+  porosity: 0.4
+  velocity: 0.001
+  column_length: 0.25
+  dz: 0.0025
+  fe: 1.5
+  ue: 0.0025
+  stationary_fraction: 0.6

--- a/examples/config/acids/scenario.yml
+++ b/examples/config/acids/scenario.yml
@@ -1,0 +1,5 @@
+initial_condition: zero
+default_injection:
+  type: Dirac
+  time: 5.0
+  amount: 0.05

--- a/examples/config/acids/scenario_gaussian.yml
+++ b/examples/config/acids/scenario_gaussian.yml
@@ -1,0 +1,6 @@
+initial_condition: zero
+default_injection:
+  type: Gaussian
+  center: 10.0
+  width: 3.0
+  peak_concentration: 0.1

--- a/examples/config/acids/solver_euler.yml
+++ b/examples/config/acids/solver_euler.yml
@@ -1,0 +1,4 @@
+type: Euler
+total_time: 1200.0
+time_steps: 20000
+step: ~

--- a/examples/config/acids/solver_rk4.yml
+++ b/examples/config/acids/solver_rk4.yml
@@ -1,0 +1,4 @@
+type: RK4
+total_time: 1200.0
+time_steps: 20000
+step: ~

--- a/examples/config/tfa/model.yml
+++ b/examples/config/tfa/model.yml
@@ -1,0 +1,11 @@
+LangmuirSingle:
+  lambda: 1.2
+  langmuir_k: 0.4
+  port_number: 2.0
+  length: 0.25
+  nz: 100
+  dz: 0.0025
+  fe: 1.5
+  ue: 0.0025
+  injection:
+    type: None

--- a/examples/config/tfa/scenario_dirac.yml
+++ b/examples/config/tfa/scenario_dirac.yml
@@ -1,0 +1,5 @@
+initial_condition: zero
+default_injection:
+  type: Dirac
+  time: 5.0
+  amount: 0.1

--- a/examples/config/tfa/scenario_gaussian.yml
+++ b/examples/config/tfa/scenario_gaussian.yml
@@ -1,0 +1,6 @@
+initial_condition: zero
+default_injection:
+  type: Gaussian
+  center: 10.0
+  width: 3.0
+  peak_concentration: 0.1

--- a/examples/config/tfa/solver_euler.yml
+++ b/examples/config/tfa/solver_euler.yml
@@ -1,0 +1,4 @@
+type: Euler
+total_time: 600.0
+time_steps: 10000
+step: ~

--- a/examples/config/tfa/solver_rk4.yml
+++ b/examples/config/tfa/solver_rk4.yml
@@ -1,0 +1,4 @@
+type: RK4
+total_time: 600.0
+time_steps: 10000
+step: ~

--- a/examples/tfa_from_config.rs
+++ b/examples/tfa_from_config.rs
@@ -1,0 +1,250 @@
+//! Example: TFA Chromatography — config-file variant
+//!
+//! Reproduces [`tfa`](tfa.rs) using the three-file configuration layout
+//! defined in DD-015. The physical parameters and simulation results are
+//! numerically identical to the direct-API variant; only the setup differs.
+//!
+//! ## Configuration files used
+//!
+//! ```text
+//! examples/config/tfa/
+//! ├── model.yml            ← LangmuirSingle column parameters
+//! ├── scenario_dirac.yml   ← Dirac injection at t = 5 s
+//! ├── scenario_gaussian.yml← Gaussian injection centered at t = 10 s
+//! ├── solver_rk4.yml       ← RK4, 600 s, 10 000 steps
+//! └── solver_euler.yml     ← Euler, 600 s, 10 000 steps
+//! ```
+//!
+//! ## How to run
+//!
+//! ```bash
+//! cargo run --example tfa_from_config
+//! ```
+//!
+//! ## Expected output
+//!
+//! Peak characteristics and retention times identical to `tfa` example.
+//! Plots written to the system temporary directory.
+
+use chrom_rs::{
+    config::{model::load_model, scenario::load_scenario, solver::load_solver},
+    output::{PlotConfig, plot_chromatogram},
+    physics::{PhysicalModel, PhysicalQuantity},
+    solver::{EulerSolver, RK4Solver, Scenario, SimulationResult, Solver},
+};
+
+use std::time::Instant;
+
+// ── Config file paths ─────────────────────────────────────────────────────────
+
+const MODEL: &str = "examples/config/tfa/model.yml";
+const SCENARIO_DIRAC: &str = "examples/config/tfa/scenario_dirac.yml";
+const SCENARIO_GAUSSIAN: &str = "examples/config/tfa/scenario_gaussian.yml";
+const SOLVER_RK4: &str = "examples/config/tfa/solver_rk4.yml";
+const SOLVER_EULER: &str = "examples/config/tfa/solver_euler.yml";
+
+// ── Run descriptor ────────────────────────────────────────────────────────────
+
+struct Run {
+    injection_name: &'static str,
+    solver_name: &'static str,
+    elapsed_secs: f64,
+    peak_concentration: f64,
+    retention_time_secs: f64,
+    final_concentration: f64,
+    result: SimulationResult,
+}
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("═══════════════════════════════════════════════════════");
+    println!("  TFA Chromatography — config-file variant (DD-015)");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    let tmp_dir = std::env::temp_dir();
+
+    // ── Simulation matrix: 2 scenarios × 2 solvers ───────────────────────────
+
+    let scenarios = [("Dirac", SCENARIO_DIRAC), ("Gaussian", SCENARIO_GAUSSIAN)];
+
+    let solver_files = [("Euler", SOLVER_EULER), ("Runge-Kutta", SOLVER_RK4)];
+
+    println!("═══════════════════════════════════════════════════════");
+    println!("  Running Simulations: 2 Scenarios × 2 Solvers");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    let mut runs: Vec<Run> = Vec::new();
+
+    for (injection_name, scenario_path) in &scenarios {
+        for (solver_name, solver_path) in &solver_files {
+            print!("  {injection_name:8} × {solver_name:12}: ");
+            std::io::Write::flush(&mut std::io::stdout())?;
+
+            let t0 = Instant::now();
+
+            // 1. Load model (injection set to None in model.yml)
+            let mut model = load_model(MODEL)?;
+
+            // 2. Load scenario — applies injection to the model in place
+            let boundaries = load_scenario(scenario_path, &mut *model)?;
+
+            // 3. Load solver configuration
+            let solver_cfg = load_solver(solver_path)?;
+
+            // 4. Build scenario and solve
+            let n_points = model.points();
+            let scenario = Scenario::new(model, boundaries);
+
+            let result = match solver_cfg.solver_name.as_str() {
+                "RK4" => RK4Solver::new().solve(&scenario, &solver_cfg.config)?,
+                "Euler" => EulerSolver::new().solve(&scenario, &solver_cfg.config)?,
+                other => return Err(format!("unknown solver '{other}'").into()),
+            };
+
+            let elapsed_secs = t0.elapsed().as_secs_f64();
+
+            // 5. Extract outlet concentration series (last spatial point)
+            let outlet: Vec<f64> = result
+                .state_trajectory
+                .iter()
+                .map(
+                    |state| match state.get(PhysicalQuantity::Concentration).unwrap() {
+                        chrom_rs::physics::PhysicalData::Vector(v) => v[n_points - 1],
+                        _ => 0.0,
+                    },
+                )
+                .collect();
+
+            let peak_concentration = outlet.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            let peak_index = outlet
+                .iter()
+                .position(|&c| (c - peak_concentration).abs() < 1e-10)
+                .unwrap_or(0);
+            let retention_time_secs = result.time_points[peak_index];
+            let final_concentration = *outlet.last().unwrap_or(&0.0);
+
+            println!("✓ {elapsed_secs:.2} s");
+
+            runs.push(Run {
+                injection_name,
+                solver_name,
+                elapsed_secs,
+                peak_concentration,
+                retention_time_secs,
+                final_concentration,
+                result,
+            });
+        }
+    }
+
+    // ── Results ───────────────────────────────────────────────────────────────
+
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("  Results: Peak Characteristics");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    println!(
+        "{:<10} {:<14} {:>12} {:>12} {:>12}",
+        "Injection", "Solver", "Peak (mol/L)", "Ret.Time (s)", "Final (mol/L)"
+    );
+    println!("{:-<60}", "");
+
+    for r in &runs {
+        println!(
+            "{:<10} {:<14} {:>12.6} {:>12.2} {:>12.6}",
+            r.injection_name,
+            r.solver_name,
+            r.peak_concentration,
+            r.retention_time_secs,
+            r.final_concentration,
+        );
+    }
+
+    // ── Performance ───────────────────────────────────────────────────────────
+
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("  Performance Comparison");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    println!("{:<10} {:<14} {:>10}", "Injection", "Solver", "Time (s)");
+    println!("{:-<35}", "");
+
+    for r in &runs {
+        println!(
+            "{:<10} {:<14} {:>10.2}",
+            r.injection_name, r.solver_name, r.elapsed_secs
+        );
+    }
+
+    let euler_dirac = runs
+        .iter()
+        .find(|r| r.injection_name == "Dirac" && r.solver_name == "Euler")
+        .unwrap();
+    let rk4_dirac = runs
+        .iter()
+        .find(|r| r.injection_name == "Dirac" && r.solver_name == "Runge-Kutta")
+        .unwrap();
+    println!(
+        "\nRK4/Euler speedup: {:.2}× slower (expected ~4×)",
+        rk4_dirac.elapsed_secs / euler_dirac.elapsed_secs
+    );
+
+    // ── Accuracy: Euler vs RK4 ────────────────────────────────────────────────
+
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("  Accuracy: Euler vs RK4");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    for injection_name in ["Dirac", "Gaussian"] {
+        let euler = runs
+            .iter()
+            .find(|r| r.injection_name == injection_name && r.solver_name == "Euler")
+            .unwrap();
+        let rk4 = runs
+            .iter()
+            .find(|r| r.injection_name == injection_name && r.solver_name == "Runge-Kutta")
+            .unwrap();
+
+        let peak_diff = (rk4.peak_concentration - euler.peak_concentration).abs();
+        let peak_pct = peak_diff / euler.peak_concentration * 100.0;
+        let rt_diff = (rk4.retention_time_secs - euler.retention_time_secs).abs();
+        let rt_ppm = rt_diff / euler.retention_time_secs * 1_000_000.0;
+
+        println!(" {injection_name} Injection:");
+        println!("  Peak difference    : {peak_diff:.6} mol/L ({peak_pct:.2}%)");
+        println!("  Ret.Time difference: {rt_diff:.4} s ({rt_ppm:.2} ppm)");
+    }
+
+    // ── Peak Validation ───────────────────────────────────────────────────────
+
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("  Peak Validation");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    for r in &runs {
+        let is_peak =
+            r.peak_concentration > 1e-3 && r.final_concentration < r.peak_concentration * 0.1;
+        let status = if is_peak { "✅ PEAK" } else { "❌ PLATEAU" };
+        println!("{:<14} {:<12}: {status}", r.injection_name, r.solver_name);
+    }
+
+    // ── Plots ─────────────────────────────────────────────────────────────────
+
+    println!("\n═══════════════════════════════════════════════════════");
+    println!("  Generating Plots");
+    println!("═══════════════════════════════════════════════════════\n");
+
+    for r in &runs {
+        let filename = format!("tfa_config_{}_{}.png", r.injection_name, r.solver_name);
+        let path = tmp_dir.join(&filename);
+        let config = PlotConfig::chromatogram(format!(
+            "TFA [config]: {} × {}",
+            r.injection_name, r.solver_name
+        ));
+        plot_chromatogram(&r.result, 100, path.to_str().unwrap(), Some(&config))?;
+        println!("  {} × {} : {path:?}", r.injection_name, r.solver_name);
+    }
+
+    Ok(())
+}

--- a/examples/tfa_from_config.rs
+++ b/examples/tfa_from_config.rs
@@ -29,7 +29,7 @@
 use chrom_rs::{
     config::{model::load_model, scenario::load_scenario, solver::load_solver},
     output::{PlotConfig, plot_chromatogram},
-    physics::{PhysicalModel, PhysicalQuantity},
+    physics::PhysicalQuantity,
     solver::{EulerSolver, RK4Solver, Scenario, SimulationResult, Solver},
 };
 

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1,0 +1,903 @@
+//! Application layer for the `chrom-rs` CLI (DD-001).
+//!
+//! Groups all runtime concerns in one place:
+//!
+//! - [`ChromContext`] / [`ContextError`]: execution context and its invariants.
+//! - [`RunHandler`]: the `run` command handler that orchestrates the full
+//!   simulation pipeline.
+//! - [`resolve_species_names`]: detects the model type from the config file
+//!   before `Box<dyn PhysicalModel>` erases it.
+//! - [`resolve_export_map`]: deserialises the model into a concrete type to
+//!   call [`Exportable::to_map`](crate::physics::Exportable) for JSON export.
+//!
+//! # Path invariants
+//!
+//! `project_dir` is always a *safe* directory:
+//! - No `..` component (prevents escaping the declared root).
+//! - The directory exists and is readable by the current process.
+//! - The directory is writable by the current process (output files land here).
+//!
+//! These invariants are enforced exclusively by
+//! [`ChromContext::set_project_dir`].
+
+use std::collections::HashMap;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::anyhow;
+use dynamic_cli::error::ExecutionError;
+use dynamic_cli::{CommandHandler, DynamicCliError, ExecutionContext};
+
+use crate::config::{model::load_model, scenario::load_scenario, solver::load_solver};
+use crate::models::{LangmuirMulti, LangmuirSingle};
+use crate::output::export::{CsvConfig, CsvExporter, Exporter, to_json};
+use crate::output::visualization::{plot_chromatogram, plot_chromatogram_multi};
+use crate::physics::Exportable;
+use crate::solver::{EulerSolver, RK4Solver, Scenario, SimulationResult, Solver};
+
+// ============================================================================
+// ContextError
+// ============================================================================
+
+/// Errors that can occur when configuring a [`ChromContext`].
+#[derive(Debug)]
+pub enum ContextError {
+    /// The path contains a `..` component.
+    PathTraversal(PathBuf),
+
+    /// The path does not point to an existing directory.
+    NotADirectory(PathBuf),
+
+    /// The current process lacks read or write permission on the directory.
+    PermissionDenied(PathBuf, io::Error),
+}
+
+impl std::fmt::Display for ContextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ContextError::PathTraversal(p) => write!(
+                f,
+                "project-dir '{}' contains '..': path traversal is not allowed",
+                p.display()
+            ),
+            ContextError::NotADirectory(p) => write!(
+                f,
+                "project-dir '{}' does not exist or is not a directory",
+                p.display()
+            ),
+            ContextError::PermissionDenied(p, e) => write!(
+                f,
+                "project-dir '{}': insufficient permissions — {e}",
+                p.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ContextError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ContextError::PermissionDenied(_, e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+// ============================================================================
+// ChromContext
+// ============================================================================
+
+/// Runtime state shared across all `chrom-rs` command handlers.
+///
+/// In v0.2.0 the only piece of state is `project_dir`: the directory
+/// relative to which `--model`, `--scenario`, `--solver`, and all output
+/// file names are resolved.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::cli::app::ChromContext;
+///
+/// let mut ctx = ChromContext::new();           // project_dir = "."
+/// ctx.set_project_dir("experiments/run_01").unwrap();
+/// assert_eq!(ctx.project_dir(), std::path::Path::new("experiments/run_01"));
+/// ```
+pub struct ChromContext {
+    /// Root directory for all file-name resolution.
+    ///
+    /// Invariants enforced by [`set_project_dir`](Self::set_project_dir):
+    /// no `..` component; existing, readable, writable directory.
+    project_dir: PathBuf,
+}
+
+impl ChromContext {
+    /// Creates a context whose project directory is the current working
+    /// directory (`.`).
+    pub fn new() -> Self {
+        Self {
+            project_dir: PathBuf::from("."),
+        }
+    }
+
+    /// Returns the current project directory.
+    pub fn project_dir(&self) -> &Path {
+        &self.project_dir
+    }
+
+    /// Sets the project directory after validating the path.
+    ///
+    /// # Validation
+    ///
+    /// 1. Rejects any path containing a `..` component.
+    /// 2. Checks that the path points to an existing directory.
+    /// 3. Verifies read permission by listing the directory.
+    /// 4. Verifies write permission by creating and removing a probe file.
+    ///
+    /// # Errors
+    ///
+    /// - [`ContextError::PathTraversal`] if `path` contains `..`.
+    /// - [`ContextError::NotADirectory`] if `path` does not exist or is a file.
+    /// - [`ContextError::PermissionDenied`] if the process cannot read or
+    ///   write the directory.
+    pub fn set_project_dir(&mut self, path: impl Into<PathBuf>) -> Result<(), ContextError> {
+        let path = path.into();
+
+        // 1 — Reject `..` regardless of position.
+        if path.components().any(|c| c == Component::ParentDir) {
+            return Err(ContextError::PathTraversal(path));
+        }
+
+        // 2 — Must be an existing directory.
+        if !path.is_dir() {
+            return Err(ContextError::NotADirectory(path));
+        }
+
+        // 3 — Read permission.
+        std::fs::read_dir(&path).map_err(|e| ContextError::PermissionDenied(path.clone(), e))?;
+
+        // 4 — Write permission: probe with a temporary file.
+        let probe = path.join(".chrom_rs_write_probe");
+        std::fs::File::create(&probe)
+            .map_err(|e| ContextError::PermissionDenied(path.clone(), e))?;
+        let _ = std::fs::remove_file(&probe);
+
+        self.project_dir = path;
+        Ok(())
+    }
+}
+
+impl Default for ChromContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ExecutionContext for ChromContext {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+// ============================================================================
+// Error conversion helper
+// ============================================================================
+
+/// Wraps any displayable error into [`DynamicCliError`] via
+/// [`ExecutionError::CommandFailed`].
+///
+/// This is the single conversion point used throughout [`RunHandler::execute`]
+/// to bridge `anyhow::Error` (and other error types) into the error type
+/// required by `CommandHandler::execute`.
+fn to_cli_err(e: impl Into<anyhow::Error>) -> DynamicCliError {
+    ExecutionError::CommandFailed(e.into()).into()
+}
+
+// ============================================================================
+// resolve_species_names
+// ============================================================================
+
+/// Reads the root key of a model file and, for multi-species models, returns
+/// the species names in declaration order.
+///
+/// Returns an empty `Vec` for single-species models (`LangmuirSingle`).
+/// This is the only place in `cli/` that knows about concrete model types —
+/// the knowledge is available here because the file has not yet been erased
+/// behind `Box<dyn PhysicalModel>`.
+///
+/// # Errors
+///
+/// Propagates I/O and parse errors from the config layer.
+pub(super) fn resolve_species_names(model_path: &Path) -> anyhow::Result<Vec<String>> {
+    let (format, content) = read_model_file(model_path)?;
+    let root_key = peek_root_key(format, &content, model_path)?;
+
+    if root_key != "LangmuirMulti" {
+        return Ok(vec![]);
+    }
+
+    let model = deserialise_inner::<LangmuirMulti>(format, &content, "LangmuirMulti", model_path)?;
+    Ok(model
+        .species_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect())
+}
+
+// ============================================================================
+// resolve_export_map
+// ============================================================================
+
+/// Builds the JSON export map for the simulation result.
+///
+/// `Exportable::to_map` is defined on concrete model types, not on
+/// `Box<dyn PhysicalModel>`. This helper re-reads and deserialises the model
+/// file into the appropriate concrete type to call `to_map`, keeping all
+/// concrete type knowledge confined to `cli/app.rs`.
+///
+/// # Errors
+///
+/// Propagates I/O, parse, and deserialisation errors.
+pub(super) fn resolve_export_map(
+    model_path: &Path,
+    result: &SimulationResult,
+) -> anyhow::Result<serde_json::Map<String, serde_json::Value>> {
+    let (format, content) = read_model_file(model_path)?;
+    let root_key = peek_root_key(format, &content, model_path)?;
+
+    match root_key.as_str() {
+        "LangmuirMulti" => {
+            let model =
+                deserialise_inner::<LangmuirMulti>(format, &content, "LangmuirMulti", model_path)?;
+            Ok(model.to_map(
+                &result.time_points,
+                &result.state_trajectory,
+                &result.metadata,
+            ))
+        }
+        _ => {
+            let model = deserialise_inner::<LangmuirSingle>(
+                format,
+                &content,
+                "LangmuirSingle",
+                model_path,
+            )?;
+            Ok(model.to_map(
+                &result.time_points,
+                &result.state_trajectory,
+                &result.metadata,
+            ))
+        }
+    }
+}
+
+// ============================================================================
+// Private model-file helpers
+// ============================================================================
+
+use crate::config::Format;
+
+/// Reads a model file and returns its detected format and raw content.
+fn read_model_file(model_path: &Path) -> anyhow::Result<(Format, String)> {
+    use crate::config::format_from_path;
+
+    let path_str = model_path
+        .to_str()
+        .ok_or_else(|| anyhow!("model path is not valid UTF-8"))?;
+
+    let format =
+        format_from_path(path_str).map_err(|e| anyhow!("unsupported model file format: {e}"))?;
+
+    let content = std::fs::read_to_string(model_path)
+        .map_err(|e| anyhow!("cannot read '{}': {e}", model_path.display()))?;
+
+    Ok((format, content))
+}
+
+/// Peeks at the root key of a YAML or JSON model file.
+fn peek_root_key(format: Format, content: &str, model_path: &Path) -> anyhow::Result<String> {
+    let key = match format {
+        Format::Yaml => {
+            let value: serde_yaml::Value = serde_yaml::from_str(content)
+                .map_err(|e| anyhow!("YAML parse error in '{}': {e}", model_path.display()))?;
+            value
+                .as_mapping()
+                .and_then(|m| m.keys().next())
+                .and_then(|k| k.as_str())
+                .unwrap_or("")
+                .to_string()
+        }
+        Format::Json => {
+            let value: serde_json::Value = serde_json::from_str(content)
+                .map_err(|e| anyhow!("JSON parse error in '{}': {e}", model_path.display()))?;
+            value
+                .as_object()
+                .and_then(|m| m.keys().next())
+                .map(|k| k.as_str())
+                .unwrap_or("")
+                .to_string()
+        }
+    };
+    Ok(key)
+}
+
+/// Extracts the inner value under `key` and deserialises it into `T`.
+fn deserialise_inner<T>(
+    format: Format,
+    content: &str,
+    key: &str,
+    model_path: &Path,
+) -> anyhow::Result<T>
+where
+    T: serde::de::DeserializeOwned,
+{
+    // Normalise through serde_json::Value so both YAML and JSON share the same
+    // deserialisation path into T.
+    let root: serde_json::Value = match format {
+        Format::Yaml => serde_yaml::from_str(content)
+            .map_err(|e| anyhow!("YAML parse error in '{}': {e}", model_path.display()))?,
+        Format::Json => serde_json::from_str(content)
+            .map_err(|e| anyhow!("JSON parse error in '{}': {e}", model_path.display()))?,
+    };
+
+    let inner = root
+        .get(key)
+        .cloned()
+        .ok_or_else(|| anyhow!("missing '{}' key in '{}'", key, model_path.display()))?;
+
+    serde_json::from_value(inner).map_err(|e| {
+        anyhow!(
+            "deserialisation error for '{}' in '{}': {e}",
+            key,
+            model_path.display()
+        )
+    })
+}
+
+// ============================================================================
+// RunHandler
+// ============================================================================
+
+/// Handler for the `run` command.
+///
+/// Orchestrates the full simulation pipeline:
+///
+/// 1. Validate and apply `--project-dir` to the context.
+/// 2. Resolve all file paths under the project directory.
+/// 3. Detect species names from the model file.
+/// 4. Load model → scenario → solver.
+/// 5. Build [`Scenario`] and dispatch to the correct [`Solver`].
+/// 6. Write requested outputs (CSV, plot, JSON export).
+pub struct RunHandler;
+
+impl CommandHandler for RunHandler {
+    fn execute(
+        &self,
+        ctx: &mut dyn ExecutionContext,
+        args: &HashMap<String, String>,
+    ) -> dynamic_cli::Result<()> {
+        // ── 1. Project directory ─────────────────────────────────────────────
+        let chrom_ctx = ctx
+            .as_any_mut()
+            .downcast_mut::<ChromContext>()
+            .ok_or_else(|| {
+                DynamicCliError::from(ExecutionError::ContextDowncastFailed {
+                    expected_type: "ChromContext".to_string(),
+                    suggestion: None,
+                })
+            })?;
+
+        let project_dir_str = args.get("project-dir").map(|s| s.as_str()).unwrap_or(".");
+
+        chrom_ctx
+            .set_project_dir(project_dir_str)
+            .map_err(|e| to_cli_err(anyhow!("{e}")))?;
+
+        let project_dir: PathBuf = chrom_ctx.project_dir().to_path_buf();
+
+        // ── 2. Resolve input file paths ──────────────────────────────────────
+        let model_path = resolve_input_path(&project_dir, args, "model").map_err(to_cli_err)?;
+        let scenario_path =
+            resolve_input_path(&project_dir, args, "scenario").map_err(to_cli_err)?;
+        let solver_path = resolve_input_path(&project_dir, args, "solver").map_err(to_cli_err)?;
+
+        // ── 3. Detect species before Box<dyn PhysicalModel> erases the type ──
+        let species_names = resolve_species_names(&model_path).map_err(to_cli_err)?;
+        let is_multi = !species_names.is_empty();
+
+        // ── 4. Load configuration ────────────────────────────────────────────
+        let model_path_str = path_to_str(&model_path).map_err(to_cli_err)?;
+        let scenario_path_str = path_to_str(&scenario_path).map_err(to_cli_err)?;
+        let solver_path_str = path_to_str(&solver_path).map_err(to_cli_err)?;
+
+        let mut model =
+            load_model(model_path_str).map_err(|e| to_cli_err(anyhow!("loading model: {e}")))?;
+
+        let boundaries = load_scenario(scenario_path_str, &mut *model)
+            .map_err(|e| to_cli_err(anyhow!("loading scenario: {e}")))?;
+
+        let solver_cfg =
+            load_solver(solver_path_str).map_err(|e| to_cli_err(anyhow!("loading solver: {e}")))?;
+
+        // ── 5. Build scenario and solve ──────────────────────────────────────
+        let scenario = Scenario::new(model, boundaries);
+
+        let result = match solver_cfg.solver_name.as_str() {
+            "RK4" => RK4Solver::new()
+                .solve(&scenario, &solver_cfg.config)
+                .map_err(|e| to_cli_err(anyhow!("RK4 solver: {e}")))?,
+            "Euler" => EulerSolver::new()
+                .solve(&scenario, &solver_cfg.config)
+                .map_err(|e| to_cli_err(anyhow!("Euler solver: {e}")))?,
+            other => {
+                return Err(to_cli_err(anyhow!(
+                    "unknown solver '{}' — expected 'RK4' or 'Euler'",
+                    other
+                )));
+            }
+        };
+
+        println!(
+            "Simulation complete — {} time points",
+            result.time_points.len()
+        );
+
+        // ── 6. Outputs ───────────────────────────────────────────────────────
+
+        // CSV
+        if let Some(csv_name) = args.get("output-csv") {
+            let csv_buf = project_dir.join(csv_name);
+            let csv_path = path_to_str(&csv_buf).map_err(to_cli_err)?;
+            let exporter = CsvExporter::new(CsvConfig::default());
+            if is_multi {
+                let name_refs: Vec<&str> = species_names.iter().map(|s| s.as_str()).collect();
+                exporter
+                    .export_multi(&result, None, &name_refs, csv_path)
+                    .map_err(|e| to_cli_err(anyhow!("CSV export: {e}")))?;
+            } else {
+                exporter
+                    .export_single(&result, None, csv_path)
+                    .map_err(|e| to_cli_err(anyhow!("CSV export: {e}")))?;
+            }
+            println!("CSV written → {csv_path}");
+        }
+
+        // Plot
+        if let Some(plot_name) = args.get("output-plot") {
+            let plot_buf = project_dir.join(plot_name);
+            let plot_path = path_to_str(&plot_buf).map_err(to_cli_err)?;
+            if is_multi {
+                let name_refs: Vec<&str> = species_names.iter().map(|s| s.as_str()).collect();
+                plot_chromatogram_multi(
+                    &result,
+                    result.time_points.len(),
+                    &name_refs,
+                    plot_path,
+                    None,
+                )
+                .map_err(|e| to_cli_err(anyhow!("plot: {e}")))?;
+            } else {
+                plot_chromatogram(&result, result.time_points.len(), plot_path, None)
+                    .map_err(|e| to_cli_err(anyhow!("plot: {e}")))?;
+            }
+            println!("Plot written → {plot_path}");
+        }
+
+        // JSON export
+        if let Some(json_name) = args.get("export-json") {
+            let json_buf = project_dir.join(json_name);
+            let json_path = path_to_str(&json_buf).map_err(to_cli_err)?;
+            let map = resolve_export_map(&model_path, &result)
+                .map_err(|e| to_cli_err(anyhow!("building export map: {e}")))?;
+            to_json(&map, json_path).map_err(|e| to_cli_err(anyhow!("JSON export: {e}")))?;
+            println!("JSON written → {json_path}");
+        }
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// Private helpers
+// ============================================================================
+
+/// Resolves a required option to a [`PathBuf`] under `project_dir`.
+fn resolve_input_path(
+    project_dir: &Path,
+    args: &HashMap<String, String>,
+    key: &str,
+) -> anyhow::Result<PathBuf> {
+    let name = args
+        .get(key)
+        .ok_or_else(|| anyhow!("missing required option '--{key}'"))?;
+    Ok(project_dir.join(name))
+}
+
+/// Converts a [`Path`] to `&str`, rejecting non-UTF-8 paths.
+fn path_to_str(path: &Path) -> anyhow::Result<&str> {
+    path.to_str()
+        .ok_or_else(|| anyhow!("path '{}' contains non-UTF-8 characters", path.display()))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
+    use crate::solver::SimulationResult;
+    use dynamic_cli::downcast_ref;
+    use std::io::Write;
+
+    // ── Fixtures YAML ─────────────────────────────────────────────────────────
+
+    const SINGLE_YAML: &str = "\
+LangmuirSingle:
+  lambda: 1.2
+  langmuir_k: 0.4
+  port_number: 2.0
+  length: 0.25
+  nz: 100
+  dz: 0.0025
+  fe: 1.5
+  ue: 0.0025
+  injection:
+    type: None
+";
+
+    const MULTI_YAML: &str = "\
+LangmuirMulti:
+  species:
+    - name: A
+      lambda: 1.0
+      langmuir_k: 0.5
+      port_number: 1
+      injection:
+        type: None
+    - name: B
+      lambda: 1.0
+      langmuir_k: 2.0
+      port_number: 1
+      injection:
+        type: None
+  n_points: 50
+  porosity: 0.4
+  velocity: 0.001
+  column_length: 0.25
+  dz: 0.005
+  fe: 1.5
+  ue: 0.0025
+  stationary_fraction: 0.6
+";
+
+    /// Écrit un fichier YAML temporaire et retourne le handle.
+    fn tmp_yaml(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    /// Écrit un fichier JSON temporaire et retourne le handle.
+    fn tmp_json(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    /// Construit un `SimulationResult` minimal pour les tests d'export.
+    fn minimal_result() -> SimulationResult {
+        let state = PhysicalState::new(
+            PhysicalQuantity::Concentration,
+            PhysicalData::Vector(nalgebra::DVector::from_vec(vec![0.0; 100])),
+        );
+        SimulationResult::new(
+            vec![0.0, 1.0, 2.0],
+            vec![state.clone(), state.clone(), state.clone()],
+            state,
+        )
+    }
+
+    // ── ChromContext ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_new_defaults_to_current_dir() {
+        let ctx = ChromContext::new();
+        assert_eq!(ctx.project_dir(), Path::new("."));
+    }
+
+    #[test]
+    fn test_default_equals_new() {
+        let ctx = ChromContext::default();
+        assert_eq!(ctx.project_dir(), Path::new("."));
+    }
+
+    #[test]
+    fn test_set_project_dir_valid() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = ChromContext::new();
+        ctx.set_project_dir(dir.path()).unwrap();
+        assert_eq!(ctx.project_dir(), dir.path());
+    }
+
+    #[test]
+    fn test_set_project_dir_rejects_parent_component() {
+        let mut ctx = ChromContext::new();
+        assert!(matches!(
+            ctx.set_project_dir("some/../other"),
+            Err(ContextError::PathTraversal(_))
+        ));
+    }
+
+    #[test]
+    fn test_set_project_dir_rejects_leading_parent() {
+        let mut ctx = ChromContext::new();
+        assert!(matches!(
+            ctx.set_project_dir("../sibling"),
+            Err(ContextError::PathTraversal(_))
+        ));
+    }
+
+    #[test]
+    fn test_set_project_dir_rejects_missing_path() {
+        let mut ctx = ChromContext::new();
+        assert!(matches!(
+            ctx.set_project_dir("/tmp/chrom_rs_does_not_exist_xyz"),
+            Err(ContextError::NotADirectory(_))
+        ));
+    }
+
+    #[test]
+    fn test_set_project_dir_rejects_file_path() {
+        let file = tempfile::NamedTempFile::new().unwrap();
+        let mut ctx = ChromContext::new();
+        assert!(matches!(
+            ctx.set_project_dir(file.path()),
+            Err(ContextError::NotADirectory(_))
+        ));
+    }
+
+    // ── ExecutionContext downcast ─────────────────────────────────────────────
+
+    #[test]
+    fn test_as_any_downcast_ref() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut ctx = ChromContext::new();
+        ctx.set_project_dir(dir.path()).unwrap();
+        let boxed: Box<dyn ExecutionContext> = Box::new(ctx);
+        let recovered = downcast_ref::<ChromContext>(boxed.as_ref()).unwrap();
+        assert_eq!(recovered.project_dir(), dir.path());
+    }
+
+    #[test]
+    fn test_as_any_mut_downcast_mut() {
+        let dir1 = tempfile::tempdir().unwrap();
+        let dir2 = tempfile::tempdir().unwrap();
+        let mut ctx = ChromContext::new();
+        ctx.set_project_dir(dir1.path()).unwrap();
+        let any_mut = ctx.as_any_mut();
+        let recovered = any_mut.downcast_mut::<ChromContext>().unwrap();
+        recovered.set_project_dir(dir2.path()).unwrap();
+        assert_eq!(ctx.project_dir(), dir2.path());
+    }
+
+    // ── ContextError ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_display_path_traversal() {
+        let e = ContextError::PathTraversal(PathBuf::from("a/../b"));
+        assert!(e.to_string().contains(".."));
+        assert!(e.to_string().contains("path traversal"));
+    }
+
+    #[test]
+    fn test_display_not_a_directory() {
+        let e = ContextError::NotADirectory(PathBuf::from("/no/such/dir"));
+        assert!(e.to_string().contains("no/such/dir"));
+    }
+
+    #[test]
+    fn test_display_permission_denied() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let e = ContextError::PermissionDenied(PathBuf::from("/locked"), io_err);
+        assert!(e.to_string().contains("locked"));
+        assert!(e.to_string().contains("permissions"));
+    }
+
+    #[test]
+    fn test_source_permission_denied_has_source() {
+        use std::error::Error;
+        let io_err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+        let e = ContextError::PermissionDenied(PathBuf::from("/locked"), io_err);
+        assert!(e.source().is_some());
+    }
+
+    #[test]
+    fn test_source_path_traversal_is_none() {
+        use std::error::Error;
+        let e = ContextError::PathTraversal(PathBuf::from("a/b"));
+        assert!(e.source().is_none());
+    }
+
+    // ── to_cli_err ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_to_cli_err_produces_command_failed() {
+        use dynamic_cli::error::DynamicCliError;
+        let err = to_cli_err(anyhow!("test error"));
+        assert!(matches!(err, DynamicCliError::Execution(_)));
+    }
+
+    // ── path_to_str ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_path_to_str_valid_utf8() {
+        let p = PathBuf::from("/tmp/results.csv");
+        assert_eq!(path_to_str(&p).unwrap(), "/tmp/results.csv");
+    }
+
+    #[test]
+    fn test_path_to_str_rejects_non_utf8() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+        let bad = OsStr::from_bytes(&[0xff, 0xfe]);
+        let p = PathBuf::from(bad);
+        assert!(path_to_str(&p).is_err());
+    }
+
+    // ── resolve_input_path ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_input_path_found() {
+        let mut args = HashMap::new();
+        args.insert("model".to_string(), "model.yml".to_string());
+        let result = resolve_input_path(Path::new("/proj"), &args, "model").unwrap();
+        assert_eq!(result, PathBuf::from("/proj/model.yml"));
+    }
+
+    #[test]
+    fn test_resolve_input_path_missing_key() {
+        let args = HashMap::new();
+        assert!(resolve_input_path(Path::new("."), &args, "model").is_err());
+    }
+
+    // ── read_model_file ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_read_model_file_yaml() {
+        let f = tmp_yaml(SINGLE_YAML);
+        let (format, content) = read_model_file(f.path()).unwrap();
+        assert_eq!(format, Format::Yaml);
+        assert!(content.contains("LangmuirSingle"));
+    }
+
+    #[test]
+    fn test_read_model_file_json() {
+        let json = r#"{"LangmuirSingle": {"lambda": 1.0}}"#;
+        let f = tmp_json(json);
+        let (format, _) = read_model_file(f.path()).unwrap();
+        assert_eq!(format, Format::Json);
+    }
+
+    #[test]
+    fn test_read_model_file_missing() {
+        let p = PathBuf::from("/tmp/chrom_rs_missing_model.yml");
+        assert!(read_model_file(&p).is_err());
+    }
+
+    // ── peek_root_key ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_peek_root_key_yaml_single() {
+        let f = tmp_yaml(SINGLE_YAML);
+        let (fmt, content) = read_model_file(f.path()).unwrap();
+        let key = peek_root_key(fmt, &content, f.path()).unwrap();
+        assert_eq!(key, "LangmuirSingle");
+    }
+
+    #[test]
+    fn test_peek_root_key_yaml_multi() {
+        let f = tmp_yaml(MULTI_YAML);
+        let (fmt, content) = read_model_file(f.path()).unwrap();
+        let key = peek_root_key(fmt, &content, f.path()).unwrap();
+        assert_eq!(key, "LangmuirMulti");
+    }
+
+    #[test]
+    fn test_peek_root_key_json() {
+        let json = r#"{"LangmuirSingle": {}}"#;
+        let f = tmp_json(json);
+        let (fmt, content) = read_model_file(f.path()).unwrap();
+        let key = peek_root_key(fmt, &content, f.path()).unwrap();
+        assert_eq!(key, "LangmuirSingle");
+    }
+
+    // ── resolve_species_names ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_species_names_single_returns_empty() {
+        let f = tmp_yaml(SINGLE_YAML);
+        let names = resolve_species_names(f.path()).unwrap();
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_species_names_multi_returns_names() {
+        let f = tmp_yaml(MULTI_YAML);
+        let names = resolve_species_names(f.path()).unwrap();
+        assert_eq!(names, vec!["A", "B"]);
+    }
+
+    #[test]
+    fn test_resolve_species_names_missing_file() {
+        let p = PathBuf::from("/tmp/chrom_rs_no_model.yml");
+        assert!(resolve_species_names(&p).is_err());
+    }
+
+    // ── deserialise_inner ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_deserialise_inner_single_yaml() {
+        let f = tmp_yaml(SINGLE_YAML);
+        let (fmt, content) = read_model_file(f.path()).unwrap();
+        let model: crate::models::LangmuirSingle =
+            deserialise_inner(fmt, &content, "LangmuirSingle", f.path()).unwrap();
+        assert_eq!(
+            model.name(),
+            "Langmuir single specie with temporal injection"
+        );
+    }
+
+    #[test]
+    fn test_deserialise_inner_multi_yaml() {
+        let f = tmp_yaml(MULTI_YAML);
+        let (fmt, content) = read_model_file(f.path()).unwrap();
+        let model: crate::models::LangmuirMulti =
+            deserialise_inner(fmt, &content, "LangmuirMulti", f.path()).unwrap();
+        assert_eq!(model.species_names(), vec!["A", "B"]);
+    }
+
+    #[test]
+    fn test_deserialise_inner_missing_key_returns_error() {
+        let f = tmp_yaml(SINGLE_YAML);
+        let (fmt, content) = read_model_file(f.path()).unwrap();
+        let result: anyhow::Result<crate::models::LangmuirMulti> =
+            deserialise_inner(fmt, &content, "LangmuirMulti", f.path());
+        assert!(result.is_err());
+    }
+
+    // ── resolve_export_map ────────────────────────────────────────────────────
+
+    #[test]
+    fn test_resolve_export_map_single() {
+        let f = tmp_yaml(SINGLE_YAML);
+        let result = minimal_result();
+        let map = resolve_export_map(f.path(), &result).unwrap();
+        assert!(!map.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_export_map_multi() {
+        let f = tmp_yaml(MULTI_YAML);
+        // Multi needs a Matrix state — build a 50×2 trajectory
+        let state = PhysicalState::new(
+            PhysicalQuantity::Concentration,
+            PhysicalData::Matrix(nalgebra::DMatrix::zeros(50, 2)),
+        );
+        let result =
+            SimulationResult::new(vec![0.0, 1.0], vec![state.clone(), state.clone()], state);
+        let map = resolve_export_map(f.path(), &result).unwrap();
+        assert!(!map.is_empty());
+    }
+
+    #[test]
+    fn test_resolve_export_map_missing_file() {
+        let p = PathBuf::from("/tmp/chrom_rs_no_model.yml");
+        let result = minimal_result();
+        assert!(resolve_export_map(&p, &result).is_err());
+    }
+}

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -423,6 +423,8 @@ impl CommandHandler for RunHandler {
             load_solver(solver_path_str).map_err(|e| to_cli_err(anyhow!("loading solver: {e}")))?;
 
         // ── 5. Build scenario and solve ──────────────────────────────────────
+        // Capture spatial point count before model is moved into Scenario.
+        let n_points = model.points();
         let scenario = Scenario::new(model, boundaries);
 
         let result = match solver_cfg.solver_name.as_str() {
@@ -471,16 +473,10 @@ impl CommandHandler for RunHandler {
             let plot_path = path_to_str(&plot_buf).map_err(to_cli_err)?;
             if is_multi {
                 let name_refs: Vec<&str> = species_names.iter().map(|s| s.as_str()).collect();
-                plot_chromatogram_multi(
-                    &result,
-                    result.time_points.len(),
-                    &name_refs,
-                    plot_path,
-                    None,
-                )
-                .map_err(|e| to_cli_err(anyhow!("plot: {e}")))?;
+                plot_chromatogram_multi(&result, n_points, &name_refs, plot_path, None)
+                    .map_err(|e| to_cli_err(anyhow!("plot: {e}")))?;
             } else {
-                plot_chromatogram(&result, result.time_points.len(), plot_path, None)
+                plot_chromatogram(&result, n_points, plot_path, None)
                     .map_err(|e| to_cli_err(anyhow!("plot: {e}")))?;
             }
             println!("Plot written → {plot_path}");

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -1,13 +1,13 @@
-//! Application layer for the `chrom-rs` CLI (DD-001).
+//! Application layer for the `chrom-rs` CLI.
 //!
 //! Groups all runtime concerns in one place:
 //!
-//! - [`ChromContext`] / [`ContextError`]: execution context and its invariants.
+//! - [`ChromContext`] / `ContextError`: execution context and its invariants.
 //! - [`RunHandler`]: the `run` command handler that orchestrates the full
 //!   simulation pipeline.
-//! - [`resolve_species_names`]: detects the model type from the config file
+//! - `resolve_species_names`: detects the model type from the config file
 //!   before `Box<dyn PhysicalModel>` erases it.
-//! - [`resolve_export_map`]: deserialises the model into a concrete type to
+//! - `resolve_export_map`: deserialises the model into a concrete type to
 //!   call [`Exportable::to_map`](crate::physics::Exportable) for JSON export.
 //!
 //! # Path invariants

--- a/src/cli/commands.yml
+++ b/src/cli/commands.yml
@@ -1,0 +1,79 @@
+metadata:
+  version: "0.2.0"
+  prompt: "chrom-rs"
+  prompt_suffix: " > "
+
+commands:
+  - name: run
+    aliases:
+      - simulate
+    description: "Run a chromatography simulation from three configuration files."
+    required: true
+    arguments: []
+    options:
+      - name: project-dir
+        short: "d"
+        long: project-dir
+        option_type: path
+        required: false
+        default: "."
+        description: "Root directory for all file names (no '..' allowed)."
+        choices: []
+
+      - name: model
+        short: "m"
+        long: model
+        option_type: string
+        required: true
+        default: ~
+        description: "Model configuration file (e.g. model.yml)."
+        choices: []
+
+      - name: scenario
+        short: "s"
+        long: scenario
+        option_type: string
+        required: true
+        default: ~
+        description: "Scenario configuration file (e.g. scenario.yml)."
+        choices: []
+
+      - name: solver
+        short: "S"
+        long: solver
+        option_type: string
+        required: true
+        default: ~
+        description: "Solver configuration file (e.g. solver.yml)."
+        choices: []
+
+      - name: output-csv
+        short: ~
+        long: output-csv
+        option_type: path
+        required: false
+        default: ~
+        description: "Write simulation results to a CSV file."
+        choices: []
+
+      - name: output-plot
+        short: ~
+        long: output-plot
+        option_type: path
+        required: false
+        default: ~
+        description: "Save chromatogram plot to a PNG or SVG file."
+        choices: []
+
+      - name: export-json
+        short: ~
+        long: export-json
+        option_type: path
+        required: false
+        default: ~
+        description: "Export full simulation result to a JSON file."
+        choices: []
+
+    implementation: run_handler
+
+global_options: []

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,8 @@
-//! Command-line interface for `chrom-rs` (DD-001).
+//! Command-line interface for `chrom-rs`.
 //!
-//! See [`app`] for the execution context, command handlers, and helpers.
+//! Assembles the `dynamic-cli` application from a declarative YAML
+//! configuration embedded at compile time and wires it to the simulation
+//! pipeline defined in the [`app`](crate::cli::app) module.
 //!
 //! # Entry point
 //!
@@ -9,7 +11,24 @@
 //!     .expect("CLI initialisation failed")
 //!     .run();
 //! ```
+//!
+//! # Command surface (v0.2.0)
+//!
+//! ```text
+//! chrom-rs run [--project-dir <dir>]
+//!              --model    <file.yml>
+//!              --scenario <file.yml>
+//!              --solver   <file.yml>
+//!              [--output-csv   <file.csv>]
+//!              [--output-plot  <file.png>]
+//!              [--export-json  <file.json>]
+//! ```
 
+/// Execution context, command handlers, and simulation helpers.
+///
+/// All runtime state ([`ChromContext`](crate::cli::app::ChromContext)),
+/// input validation, and the `run` command handler
+/// ([`RunHandler`](crate::cli::app::RunHandler)) live here.
 pub mod app;
 
 use anyhow::anyhow;
@@ -22,15 +41,16 @@ use app::{ChromContext, RunHandler};
 // Embedded command configuration
 // ============================================================================
 
-/// Content of `src/cli/commands.yml`, embedded at compile time.
+/// YAML command configuration, embedded at compile time from
+/// `src/cli/commands.yml`.
 ///
-/// Parsed once in [`build_app`] via [`load_yaml`]. Keeping the declarations
-/// in YAML lets maintainers adjust help text, aliases, and option metadata
+/// Parsed once in [`build_app`] via `load_yaml`. Keeping the declarations in
+/// YAML lets maintainers adjust help text, aliases, and option metadata
 /// without touching Rust code.
 const COMMANDS_YML: &str = include_str!("commands.yml");
 
-/// Implementation name — must match the `implementation:` field in
-/// `commands.yml` for the `run` command.
+/// Handler name that must match the `implementation:` field of the `run`
+/// command in `commands.yml`.
 const RUN_HANDLER_NAME: &str = "run_handler";
 
 // ============================================================================
@@ -39,13 +59,15 @@ const RUN_HANDLER_NAME: &str = "run_handler";
 
 /// Assembles and returns the fully configured [`CliApp`].
 ///
-/// Parses the embedded [`COMMANDS_YML`], wires [`RunHandler`] and a fresh
-/// [`ChromContext`], then builds the application.
+/// Parses the embedded command YAML, wires
+/// [`RunHandler`] and a fresh
+/// [`ChromContext`], then delegates to
+/// `CliBuilder::build`.
 ///
 /// # Errors
 ///
-/// Returns an error if the embedded YAML is malformed or if the builder
-/// detects a missing required handler.
+/// - The embedded YAML is malformed (compile-time regression).
+/// - The builder detects a missing required handler.
 pub fn build_app() -> anyhow::Result<CliApp> {
     let config =
         load_yaml(COMMANDS_YML).map_err(|e| anyhow!("embedded commands.yml is invalid: {e}"))?;
@@ -73,8 +95,6 @@ mod tests {
 
     #[test]
     fn test_commands_yml_is_valid_yaml() {
-        // Vérifie que le YAML embarqué est syntaxiquement correct
-        // et contient la commande `run`.
         use dynamic_cli::config::loader::load_yaml;
         let config = load_yaml(COMMANDS_YML).expect("COMMANDS_YML must be valid");
         assert!(config.commands.iter().any(|c| c.name == "run"));

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,11 +5,9 @@
 //! # Entry point
 //!
 //! ```rust,no_run
-//! fn main() {
-//!     chrom_rs::cli::build_app()
-//!         .expect("CLI initialisation failed")
-//!         .run();
-//! }
+//! chrom_rs::cli::build_app()
+//!     .expect("CLI initialisation failed")
+//!     .run();
 //! ```
 
 pub mod app;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,84 @@
+//! Command-line interface for `chrom-rs` (DD-001).
+//!
+//! See [`app`] for the execution context, command handlers, and helpers.
+//!
+//! # Entry point
+//!
+//! ```rust,no_run
+//! fn main() {
+//!     chrom_rs::cli::build_app()
+//!         .expect("CLI initialisation failed")
+//!         .run();
+//! }
+//! ```
+
+pub mod app;
+
+use anyhow::anyhow;
+use dynamic_cli::config::loader::load_yaml;
+use dynamic_cli::{CliApp, CliBuilder};
+
+use app::{ChromContext, RunHandler};
+
+// ============================================================================
+// Embedded command configuration
+// ============================================================================
+
+/// Content of `src/cli/commands.yml`, embedded at compile time.
+///
+/// Parsed once in [`build_app`] via [`load_yaml`]. Keeping the declarations
+/// in YAML lets maintainers adjust help text, aliases, and option metadata
+/// without touching Rust code.
+const COMMANDS_YML: &str = include_str!("commands.yml");
+
+/// Implementation name — must match the `implementation:` field in
+/// `commands.yml` for the `run` command.
+const RUN_HANDLER_NAME: &str = "run_handler";
+
+// ============================================================================
+// build_app
+// ============================================================================
+
+/// Assembles and returns the fully configured [`CliApp`].
+///
+/// Parses the embedded [`COMMANDS_YML`], wires [`RunHandler`] and a fresh
+/// [`ChromContext`], then builds the application.
+///
+/// # Errors
+///
+/// Returns an error if the embedded YAML is malformed or if the builder
+/// detects a missing required handler.
+pub fn build_app() -> anyhow::Result<CliApp> {
+    let config =
+        load_yaml(COMMANDS_YML).map_err(|e| anyhow!("embedded commands.yml is invalid: {e}"))?;
+
+    CliBuilder::new()
+        .config(config)
+        .context(Box::new(ChromContext::new()))
+        .register_handler(RUN_HANDLER_NAME, Box::new(RunHandler))
+        .build()
+        .map_err(|e| anyhow!("CLI builder error: {e}"))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_app_succeeds() {
+        assert!(build_app().is_ok());
+    }
+
+    #[test]
+    fn test_commands_yml_is_valid_yaml() {
+        // Vérifie que le YAML embarqué est syntaxiquement correct
+        // et contient la commande `run`.
+        use dynamic_cli::config::loader::load_yaml;
+        let config = load_yaml(COMMANDS_YML).expect("COMMANDS_YML must be valid");
+        assert!(config.commands.iter().any(|c| c.name == "run"));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,10 +5,9 @@
 //!
 //! | Loader | File | Returns |
 //! |---|---|---|
-//! | [`model::load_model`] | `model.yml` | `Box<dyn PhysicalModel>` |
-//! | [`scenario::load_scenario`] | `scenario.yml` | `DomainBoundaries` |
-//! | [`solver::load_solver`] | `solver.yml` | `SolverConfiguration` |
-//!
+//! | [`load_model`](crate::config::model::load_model) | `model.yml` | `Box<dyn PhysicalModel>` |
+//! | [`load_scenario`](crate::config::scenario::load_scenario) | `scenario.yml` | `DomainBoundaries` |
+//! | [`load_solver`](crate::config::solver::load_solver) | `solver.yml` | `SolverConfiguration` |//!
 //! # Supported formats
 //!
 //! Both JSON and YAML are accepted. The format is inferred from the file
@@ -31,8 +30,11 @@ use std::fmt;
 use std::fs;
 use std::path::Path;
 
+/// Loader for `model.yml` — returns a boxed [`PhysicalModel`](crate::physics::PhysicalModel).
 pub mod model;
+/// Loader for `scenario.yml` — applies injections and returns [`DomainBoundaries`](crate::solver::DomainBoundaries).
 pub mod scenario;
+/// Loader for `solver.yml` — returns a [`SolverConfiguration`](crate::solver::SolverConfiguration).
 pub mod solver;
 
 // ============================================================================

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,0 +1,262 @@
+//! Configuration file loading for `chrom-rs` (DD-015).
+//!
+//! Provides three independent loaders — one per configuration file — that
+//! reflect the WHAT/HOW separation at the user level (DD-003):
+//!
+//! | Loader | File | Returns |
+//! |---|---|---|
+//! | [`model::load_model`] | `model.yml` | `Box<dyn PhysicalModel>` |
+//! | [`scenario::load_scenario`] | `scenario.yml` | `DomainBoundaries` |
+//! | [`solver::load_solver`] | `solver.yml` | `SolverConfiguration` |
+//!
+//! # Supported formats
+//!
+//! Both JSON and YAML are accepted. The format is inferred from the file
+//! extension: `.yml` / `.yaml` → serde_yaml, `.json` → serde_json.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use chrom_rs::config::{model, scenario, solver};
+//! use chrom_rs::solver::Scenario;
+//!
+//! let mut phys_model = model::load_model("model_tfa.yml").unwrap();
+//! let boundaries = scenario::load_scenario("scenario_step.yml", &mut *phys_model).unwrap();
+//! let solver_config = solver::load_solver("solver_rk4.yml").unwrap();
+//!
+//! let scenario = Scenario::new(phys_model, boundaries);
+//! ```
+
+use std::fmt;
+use std::fs;
+use std::path::Path;
+
+pub mod model;
+pub mod scenario;
+pub mod solver;
+
+// ============================================================================
+// ConfigError
+// ============================================================================
+
+/// Errors that can occur while loading a configuration file.
+#[derive(Debug)]
+pub enum ConfigError {
+    /// The file could not be read (not found, permission denied, …).
+    Io(std::io::Error),
+
+    /// The file extension is not `.yml`, `.yaml`, or `.json`.
+    UnsupportedFormat(String),
+
+    /// The file content is syntactically invalid (YAML / JSON parse error).
+    Parse(String),
+
+    /// The file parsed successfully but violates a domain constraint
+    /// (e.g. a species named in `injections` does not exist in the model).
+    Validation(String),
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigError::Io(e) => write!(f, "config I/O error: {e}"),
+            ConfigError::UnsupportedFormat(ext) => {
+                write!(f, "unsupported config format '{ext}' (use .yml, .yaml or .json)")
+            }
+            ConfigError::Parse(msg) => write!(f, "config parse error: {msg}"),
+            ConfigError::Validation(msg) => write!(f, "config validation error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ConfigError::Io(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for ConfigError {
+    fn from(e: std::io::Error) -> Self {
+        ConfigError::Io(e)
+    }
+}
+
+// ============================================================================
+// Format detection
+// ============================================================================
+
+/// Recognised configuration file formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Format {
+    Yaml,
+    Json,
+}
+
+/// Infers the file format from the path extension.
+///
+/// # Errors
+///
+/// Returns [`ConfigError::UnsupportedFormat`] if the extension is absent or
+/// not one of `.yml`, `.yaml`, `.json`.
+pub(crate) fn format_from_path(path: &str) -> Result<Format, ConfigError> {
+    match Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("yml") | Some("yaml") => Ok(Format::Yaml),
+        Some("json") => Ok(Format::Json),
+        Some(other) => Err(ConfigError::UnsupportedFormat(other.to_string())),
+        None => Err(ConfigError::UnsupportedFormat(String::new())),
+    }
+}
+
+// ============================================================================
+// Generic loader helper
+// ============================================================================
+
+/// Reads a file and deserialises it into `T`, dispatching on the extension.
+///
+/// Used by [`model::load_model`] and [`solver::load_solver`] where the target
+/// type implements `serde::de::DeserializeOwned` directly. The scenario loader
+/// uses [`format_from_path`] + manual field extraction instead, because
+/// `scenario.yml` feeds multiple existing types rather than a single struct.
+pub(crate) fn load_from_file<T>(path: &str) -> Result<T, ConfigError>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let content = fs::read_to_string(path)?;
+    match format_from_path(path)? {
+        Format::Yaml => {
+            serde_yaml::from_str(&content).map_err(|e| ConfigError::Parse(e.to_string()))
+        }
+        Format::Json => {
+            serde_json::from_str(&content).map_err(|e| ConfigError::Parse(e.to_string()))
+        }
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── format_from_path ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_format_yml() {
+        assert_eq!(format_from_path("model.yml").unwrap(), Format::Yaml);
+    }
+
+    #[test]
+    fn test_format_yaml() {
+        assert_eq!(format_from_path("config/solver.yaml").unwrap(), Format::Yaml);
+    }
+
+    #[test]
+    fn test_format_json() {
+        assert_eq!(format_from_path("results/model.json").unwrap(), Format::Json);
+    }
+
+    #[test]
+    fn test_format_case_insensitive() {
+        assert_eq!(format_from_path("model.YML").unwrap(), Format::Yaml);
+        assert_eq!(format_from_path("model.JSON").unwrap(), Format::Json);
+    }
+
+    #[test]
+    fn test_format_unsupported_extension() {
+        let err = format_from_path("model.toml").unwrap_err();
+        assert!(matches!(err, ConfigError::UnsupportedFormat(ref s) if s == "toml"));
+    }
+
+    #[test]
+    fn test_format_no_extension() {
+        let err = format_from_path("model").unwrap_err();
+        assert!(matches!(err, ConfigError::UnsupportedFormat(ref s) if s.is_empty()));
+    }
+
+    // ── ConfigError display ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_display_unsupported_format() {
+        let e = ConfigError::UnsupportedFormat("toml".to_string());
+        assert!(e.to_string().contains("toml"));
+    }
+
+    #[test]
+    fn test_display_parse() {
+        let e = ConfigError::Parse("unexpected field".to_string());
+        assert!(e.to_string().contains("unexpected field"));
+    }
+
+    #[test]
+    fn test_display_validation() {
+        let e = ConfigError::Validation("species 'X' not found".to_string());
+        assert!(e.to_string().contains("species 'X'"));
+    }
+
+    #[test]
+    fn test_display_io() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+        let e = ConfigError::from(io_err);
+        assert!(e.to_string().contains("I/O"));
+    }
+
+    // ── load_from_file ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_from_file_yaml() {
+        use std::io::Write;
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        writeln!(f, "solver_type: !TimeEvolution\n  total_time: 10.0\n  time_steps: 100").unwrap();
+
+        use crate::solver::SolverConfiguration;
+        let config: SolverConfiguration =
+            load_from_file(f.path().to_str().unwrap()).unwrap();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_load_from_file_json() {
+        use std::io::Write;
+        let mut f = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        writeln!(
+            f,
+            r#"{{"solver_type":{{"TimeEvolution":{{"total_time":10.0,"time_steps":100}}}}}}"#
+        )
+        .unwrap();
+
+        use crate::solver::SolverConfiguration;
+        let config: SolverConfiguration =
+            load_from_file(f.path().to_str().unwrap()).unwrap();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_load_from_file_missing_file() {
+        use crate::solver::SolverConfiguration;
+        let result: Result<SolverConfiguration, _> =
+            load_from_file("/tmp/does_not_exist_chrom_rs_config.yml");
+        assert!(matches!(result, Err(ConfigError::Io(_))));
+    }
+
+    #[test]
+    fn test_load_from_file_invalid_yaml() {
+        use std::io::Write;
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        writeln!(f, "not: valid: yaml: at: all: [").unwrap();
+
+        use crate::solver::SolverConfiguration;
+        let result: Result<SolverConfiguration, _> =
+            load_from_file(f.path().to_str().unwrap());
+        assert!(matches!(result, Err(ConfigError::Parse(_))));
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,7 +1,7 @@
-//! Configuration file loading for `chrom-rs` (DD-015).
+//! Configuration file loading for `chrom-rs`.
 //!
 //! Provides three independent loaders — one per configuration file — that
-//! reflect the WHAT/HOW separation at the user level (DD-003):
+//! reflect the architecture separation between what and how at the user level :
 //!
 //! | Loader | File | Returns |
 //! |---|---|---|

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -61,7 +61,10 @@ impl fmt::Display for ConfigError {
         match self {
             ConfigError::Io(e) => write!(f, "config I/O error: {e}"),
             ConfigError::UnsupportedFormat(ext) => {
-                write!(f, "unsupported config format '{ext}' (use .yml, .yaml or .json)")
+                write!(
+                    f,
+                    "unsupported config format '{ext}' (use .yml, .yaml or .json)"
+                )
             }
             ConfigError::Parse(msg) => write!(f, "config parse error: {msg}"),
             ConfigError::Validation(msg) => write!(f, "config validation error: {msg}"),
@@ -129,8 +132,10 @@ pub(crate) fn load_from_file<T>(path: &str) -> Result<T, ConfigError>
 where
     T: serde::de::DeserializeOwned,
 {
+    // Check format first — returns UnsupportedFormat before any I/O attempt.
+    let format = format_from_path(path)?;
     let content = fs::read_to_string(path)?;
-    match format_from_path(path)? {
+    match format {
         Format::Yaml => {
             serde_yaml::from_str(&content).map_err(|e| ConfigError::Parse(e.to_string()))
         }
@@ -157,12 +162,18 @@ mod tests {
 
     #[test]
     fn test_format_yaml() {
-        assert_eq!(format_from_path("config/solver.yaml").unwrap(), Format::Yaml);
+        assert_eq!(
+            format_from_path("config/solver.yaml").unwrap(),
+            Format::Yaml
+        );
     }
 
     #[test]
     fn test_format_json() {
-        assert_eq!(format_from_path("results/model.json").unwrap(), Format::Json);
+        assert_eq!(
+            format_from_path("results/model.json").unwrap(),
+            Format::Json
+        );
     }
 
     #[test]
@@ -216,11 +227,14 @@ mod tests {
     fn test_load_from_file_yaml() {
         use std::io::Write;
         let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
-        writeln!(f, "solver_type: !TimeEvolution\n  total_time: 10.0\n  time_steps: 100").unwrap();
+        writeln!(
+            f,
+            "solver_type: !TimeEvolution\n  total_time: 10.0\n  time_steps: 100"
+        )
+        .unwrap();
 
         use crate::solver::SolverConfiguration;
-        let config: SolverConfiguration =
-            load_from_file(f.path().to_str().unwrap()).unwrap();
+        let config: SolverConfiguration = load_from_file(f.path().to_str().unwrap()).unwrap();
         assert!(config.validate().is_ok());
     }
 
@@ -235,8 +249,7 @@ mod tests {
         .unwrap();
 
         use crate::solver::SolverConfiguration;
-        let config: SolverConfiguration =
-            load_from_file(f.path().to_str().unwrap()).unwrap();
+        let config: SolverConfiguration = load_from_file(f.path().to_str().unwrap()).unwrap();
         assert!(config.validate().is_ok());
     }
 
@@ -255,8 +268,7 @@ mod tests {
         writeln!(f, "not: valid: yaml: at: all: [").unwrap();
 
         use crate::solver::SolverConfiguration;
-        let result: Result<SolverConfiguration, _> =
-            load_from_file(f.path().to_str().unwrap());
+        let result: Result<SolverConfiguration, _> = load_from_file(f.path().to_str().unwrap());
         assert!(matches!(result, Err(ConfigError::Parse(_))));
     }
 }

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,0 +1,236 @@
+//! Loader for `model.yml` / `model.json` (DD-015).
+//!
+//! `model.yml` describes the physical column and its parameters.
+//! The injection profile is intentionally absent (or set to `None`) here —
+//! it is supplied by `scenario.yml` and applied by [`scenario::load_scenario`].
+//!
+//! # File format
+//!
+//! The file is deserialised via `typetag`, which uses the type name as the
+//! root key. Supported formats: `.yml` / `.yaml` (serde_yaml) and `.json`
+//! (serde_json). The extension determines the parser.
+//!
+//! ## `LangmuirSingle` example
+//!
+//! ```yaml
+//! LangmuirSingle:
+//!   lambda: 1.2
+//!   langmuir_k: 0.4
+//!   port_number: 2.0
+//!   porosity: 0.4
+//!   velocity: 0.001
+//!   column_length: 0.25
+//!   nz: 100
+//!   injection:
+//!     type: None
+//! ```
+//!
+//! ## `LangmuirMulti` example
+//!
+//! ```yaml
+//! LangmuirMulti:
+//!   species:
+//!     - name: Ascorbic
+//!       lambda: 1.0
+//!       langmuir_k: 1.1
+//!       port_number: 2
+//!       injection:
+//!         type: None
+//!     - name: Erythorbic
+//!       lambda: 1.0
+//!       langmuir_k: 1.7
+//!       port_number: 2
+//!       injection:
+//!         type: None
+//!   n_points: 100
+//!   porosity: 0.4
+//!   velocity: 0.001
+//!   column_length: 0.25
+//! ```
+//!
+//! The `injection: type: None` placeholder is replaced by
+//! [`scenario::load_scenario`] after the model is loaded.
+
+use crate::config::ConfigError;
+use crate::physics::PhysicalModel;
+
+/// Loads a physical model from a configuration file.
+///
+/// The file is deserialised via `typetag` — the root key must match the
+/// registered type name (e.g. `LangmuirSingle`, `LangmuirMulti`).
+///
+/// The returned model has its injection profile set to `None` by convention.
+/// Call [`scenario::load_scenario`](super::scenario::load_scenario) to apply
+/// the injection defined in `scenario.yml`.
+///
+/// # Errors
+///
+/// - [`ConfigError::Io`] if the file cannot be read.
+/// - [`ConfigError::UnsupportedFormat`] if the extension is not `.yml`,
+///   `.yaml`, or `.json`.
+/// - [`ConfigError::Parse`] if the file content is not valid YAML/JSON or
+///   does not match a known `PhysicalModel` type.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::config::model::load_model;
+///
+/// let model = load_model("model_tfa.yml").unwrap();
+/// println!("Loaded: {}", model.name());
+/// ```
+pub fn load_model(path: &str) -> Result<Box<dyn PhysicalModel>, ConfigError> {
+    crate::config::load_from_file::<Box<dyn PhysicalModel>>(path)
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// Writes a temporary YAML file and returns it (kept alive for the test).
+    fn tmp_yaml(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    /// Writes a temporary JSON file and returns it (kept alive for the test).
+    fn tmp_json(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    const LANGMUIR_SINGLE_YAML: &str = "\
+LangmuirSingle:
+  lambda: 1.2
+  langmuir_k: 0.4
+  port_number: 2.0
+  length: 0.25
+  nz: 100
+  dz: 0.0025
+  fe: 1.5
+  ue: 0.0025
+  injection:
+    type: None
+";
+
+    const LANGMUIR_MULTI_YAML: &str = "\
+LangmuirMulti:
+  species:
+    - name: A
+      lambda: 1.0
+      langmuir_k: 0.5
+      port_number: 1
+      injection:
+        type: None
+    - name: B
+      lambda: 1.0
+      langmuir_k: 2.0
+      port_number: 1
+      injection:
+        type: None
+  n_points: 50
+  porosity: 0.4
+  velocity: 0.001
+  column_length: 0.25
+  dz: 0.005
+  fe: 1.5
+  ue: 0.0025
+  stationary_fraction: 0.6
+";
+
+    // ── Success paths ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_langmuir_single_yaml() {
+        let f = tmp_yaml(LANGMUIR_SINGLE_YAML);
+        let model = load_model(f.path().to_str().unwrap())
+            .expect("load_model must succeed for LangmuirSingle YAML");
+
+        assert_eq!(
+            model.name(),
+            "Langmuir single specie with temporal injection"
+        );
+        assert_eq!(model.points(), 100);
+    }
+
+    #[test]
+    fn test_load_langmuir_multi_yaml() {
+        let f = tmp_yaml(LANGMUIR_MULTI_YAML);
+        let model = load_model(f.path().to_str().unwrap())
+            .expect("load_model must succeed for LangmuirMulti YAML");
+
+        assert_eq!(model.name(), "Langmuir Multi-Species");
+        assert_eq!(model.points(), 50);
+    }
+
+    #[test]
+    fn test_load_langmuir_single_json() {
+        let json = r#"{
+  "LangmuirSingle": {
+    "lambda": 1.2,
+    "langmuir_k": 0.4,
+    "port_number": 2.0,
+    "length": 0.25,
+    "nz": 100,
+    "dz": 0.0025,
+    "fe": 1.5,
+    "ue": 0.0025,
+    "injection": { "type": "None" }
+  }
+}"#;
+        let f = tmp_json(json);
+        let model = load_model(f.path().to_str().unwrap())
+            .expect("load_model must succeed for LangmuirSingle JSON");
+
+        assert_eq!(model.points(), 100);
+    }
+
+    // ── Error paths ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_model_file_not_found() {
+        let result = load_model("/tmp/does_not_exist_chrom_rs_model.yml");
+        assert!(
+            matches!(result, Err(ConfigError::Io(_))),
+            "Missing file must yield ConfigError::Io"
+        );
+    }
+
+    #[test]
+    fn test_load_model_unsupported_extension() {
+        let result = load_model("model.toml");
+        assert!(
+            matches!(result, Err(ConfigError::UnsupportedFormat(_))),
+            "Unknown extension must yield ConfigError::UnsupportedFormat"
+        );
+    }
+
+    #[test]
+    fn test_load_model_invalid_yaml_syntax() {
+        let f = tmp_yaml("not: valid: yaml: [");
+        let result = load_model(f.path().to_str().unwrap());
+        assert!(
+            matches!(result, Err(ConfigError::Parse(_))),
+            "Malformed YAML must yield ConfigError::Parse"
+        );
+    }
+
+    #[test]
+    fn test_load_model_unknown_type() {
+        let f = tmp_yaml("UnknownModel:\n  field: 42\n");
+        let result = load_model(f.path().to_str().unwrap());
+        assert!(
+            matches!(result, Err(ConfigError::Parse(_))),
+            "Unknown typetag type must yield ConfigError::Parse"
+        );
+    }
+}

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -1,4 +1,4 @@
-//! Loader for `model.yml` / `model.json` (DD-015).
+//! Loader for `model.yml` / `model.json`.
 //!
 //! `model.yml` describes the physical column and its parameters.
 //! The injection profile is intentionally absent (or set to `None`) here —

--- a/src/config/scenario.rs
+++ b/src/config/scenario.rs
@@ -1,4 +1,4 @@
-//! Loader for `scenario.yml` / `scenario.json` (DD-015).
+//! Loader for `scenario.yml` / `scenario.json`.
 //!
 //! `scenario.yml` defines the **boundary conditions** for a simulation run:
 //! the initial column state and the temporal injection profile(s). It is

--- a/src/config/scenario.rs
+++ b/src/config/scenario.rs
@@ -1,0 +1,409 @@
+//! Loader for `scenario.yml` / `scenario.json` (DD-015).
+//!
+//! `scenario.yml` defines the **boundary conditions** for a simulation run:
+//! the initial column state and the temporal injection profile(s). It is
+//! intentionally decoupled from `model.yml` so that the same physical model
+//! can be driven by different injection protocols without modification.
+//!
+//! # File format
+//!
+//! ```yaml
+//! # Initial column state
+//! initial_condition: zero   # only supported value in v0.2.0
+//!
+//! # Default injection applied to all species not listed in `injections`
+//! default_injection:
+//!   type: Gaussian
+//!   center: 10.0
+//!   width: 3.0
+//!   peak_concentration: 0.1
+//!
+//! # Optional per-species overrides (LangmuirMulti only)
+//! injections:
+//!   - species: Erythorbic
+//!     type: Dirac
+//!     time: 5.0
+//!     amount: 0.05
+//! ```
+//!
+//! If `default_injection` is absent, all species keep the `None` profile
+//! they received from `load_model`. If `injections` is absent or empty,
+//! `default_injection` applies to all species.
+//!
+//! # Design note
+//!
+//! This loader does **not** deserialise into an intermediate struct.
+//! It reads the YAML/JSON fields, constructs [`TemporalInjection`] values
+//! directly, and applies them to the model via [`PhysicalModel::set_default_injection`]
+//! and [`PhysicalModel::set_injection_for_species`]. The result is a fully
+//! initialised [`DomainBoundaries`] built from `initial_condition`.
+
+use crate::config::{ConfigError, Format, format_from_path};
+use crate::models::TemporalInjection;
+use crate::physics::PhysicalModel;
+use crate::solver::DomainBoundaries;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::fs;
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Loads boundary conditions from a scenario file and applies injections to
+/// the model.
+///
+/// # Arguments
+///
+/// * `path`  — Path to `scenario.yml` or `scenario.json`.
+/// * `model` — Mutable reference to the model loaded by
+///   [`model::load_model`](super::model::load_model). Injections defined in
+///   the scenario are applied in-place via the [`PhysicalModel`] trait.
+///
+/// # Returns
+///
+/// A [`DomainBoundaries`] built from `initial_condition`. Pass it to
+/// [`Scenario::new`](crate::solver::Scenario::new) along with the model.
+///
+/// # Errors
+///
+/// - [`ConfigError::Io`] if the file cannot be read.
+/// - [`ConfigError::UnsupportedFormat`] if the extension is not recognised.
+/// - [`ConfigError::Parse`] if the content is not valid YAML/JSON.
+/// - [`ConfigError::Validation`] if:
+///   - `initial_condition` has an unrecognised value.
+///   - An injection type is unrecognised or missing required fields.
+///   - A named species in `injections` is not found in the model.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::config::{model, scenario, solver};
+/// use chrom_rs::solver::Scenario;
+///
+/// let mut phys_model = model::load_model("model_tfa.yml").unwrap();
+/// let boundaries = scenario::load_scenario("scenario_step.yml", &mut *phys_model).unwrap();
+/// let solver_cfg = solver::load_solver("solver_rk4.yml").unwrap();
+///
+/// let sc = Scenario::new(phys_model, boundaries);
+/// ```
+pub fn load_scenario(
+    path: &str,
+    model: &mut dyn PhysicalModel,
+) -> Result<DomainBoundaries, ConfigError> {
+    let content = fs::read_to_string(path)?;
+
+    // Normalise to a serde_json::Value regardless of source format.
+    let root: Value = match format_from_path(path)? {
+        Format::Yaml => {
+            serde_yaml::from_str(&content).map_err(|e| ConfigError::Parse(e.to_string()))?
+        }
+        Format::Json => {
+            serde_json::from_str(&content).map_err(|e| ConfigError::Parse(e.to_string()))?
+        }
+    };
+
+    // ── initial_condition ─────────────────────────────────────────────────────
+    let _initial_cond = root
+        .get("initial_condition")
+        .and_then(|v| v.as_str())
+        .unwrap_or("zero");
+
+    // v0.2.0: only "zero" is supported.
+    if _initial_cond != "zero" {
+        return Err(ConfigError::Validation(format!(
+            "unsupported initial_condition '{_initial_cond}' (only 'zero' is supported in v0.2.0)"
+        )));
+    }
+
+    let initial = model.setup_initial_state();
+    let boundaries = DomainBoundaries::temporal(initial);
+
+    // ── Build injection map ───────────────────────────────────────────────────
+    //
+    // The map is constructed in full before calling set_injections once.
+    // Key None   → default injection applied to all unlisted species.
+    // Key Some   → per-species override.
+    let mut injection_map: HashMap<Option<String>, crate::models::TemporalInjection> =
+        HashMap::new();
+
+    if let Some(inj_val) = root.get("default_injection") {
+        let inj = parse_injection(inj_val)?;
+        injection_map.insert(None, inj);
+    }
+
+    if let Some(Value::Array(overrides)) = root.get("injections") {
+        for entry in overrides {
+            let species = entry
+                .get("species")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    ConfigError::Validation(
+                        "each entry in 'injections' must have a 'species' field".into(),
+                    )
+                })?;
+
+            let inj = parse_injection(entry)?;
+            injection_map.insert(Some(species.to_string()), inj);
+        }
+    }
+
+    if !injection_map.is_empty() {
+        model
+            .set_injections(&injection_map)
+            .map_err(ConfigError::Validation)?;
+    }
+
+    Ok(boundaries)
+}
+
+// ============================================================================
+// Injection parser
+// ============================================================================
+
+/// Parses a `TemporalInjection` from a JSON `Value` node.
+///
+/// Accepts the same field names as `TemporalInjectionSnapshot` (the internal
+/// serde representation). The `"type"` field selects the variant; remaining
+/// fields supply the parameters.
+///
+/// | `type`      | Required fields                              |
+/// |-------------|----------------------------------------------|
+/// | `Dirac`     | `time`, `amount`                             |
+/// | `Gaussian`  | `center`, `width`, `peak_concentration`      |
+/// | `Rectangle` | `start`, `end`, `concentration`              |
+/// | `None`      | *(none)*                                     |
+fn parse_injection(v: &Value) -> Result<TemporalInjection, ConfigError> {
+    let kind = v
+        .get("type")
+        .and_then(|t| t.as_str())
+        .ok_or_else(|| ConfigError::Validation("injection block missing 'type' field".into()))?;
+
+    match kind {
+        "Dirac" => {
+            let time = req_f64(v, "time")?;
+            let amount = req_f64(v, "amount")?;
+            Ok(TemporalInjection::dirac(time, amount))
+        }
+        "Gaussian" => {
+            let center = req_f64(v, "center")?;
+            let width = req_f64(v, "width")?;
+            let peak = req_f64(v, "peak_concentration")?;
+            Ok(TemporalInjection::gaussian(center, width, peak))
+        }
+        "Rectangle" => {
+            let start = req_f64(v, "start")?;
+            let end = req_f64(v, "end")?;
+            let concentration = req_f64(v, "concentration")?;
+            Ok(TemporalInjection::rectangle(start, end, concentration))
+        }
+        "None" => Ok(TemporalInjection::none()),
+        other => Err(ConfigError::Validation(format!(
+            "unknown injection type '{other}' (expected Dirac, Gaussian, Rectangle, or None)"
+        ))),
+    }
+}
+
+/// Extracts a required `f64` field from a JSON object.
+fn req_f64(v: &Value, key: &str) -> Result<f64, ConfigError> {
+    v.get(key)
+        .and_then(|f| f.as_f64())
+        .ok_or_else(|| ConfigError::Validation(format!("injection missing required field '{key}'")))
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::{LangmuirSingle, TemporalInjection};
+    use std::io::Write;
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    fn tmp_yaml(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    fn tmp_json(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    fn single_model() -> LangmuirSingle {
+        LangmuirSingle::new(
+            1.2,
+            0.4,
+            2.0,
+            0.4,
+            0.001,
+            0.25,
+            100,
+            TemporalInjection::none(),
+        )
+    }
+
+    // ── initial_condition ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_scenario_zero_ic() {
+        let f = tmp_yaml("initial_condition: zero\n");
+        let mut model = single_model();
+        let boundaries = load_scenario(f.path().to_str().unwrap(), &mut model).unwrap();
+        assert!(boundaries.is_time_dependent());
+        assert!(boundaries.initial_condition().is_some());
+    }
+
+    #[test]
+    fn test_load_scenario_missing_ic_defaults_to_zero() {
+        // No initial_condition key → defaults to "zero"
+        let f = tmp_yaml("default_injection:\n  type: None\n");
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_load_scenario_unsupported_ic() {
+        let f = tmp_yaml("initial_condition: uniform\n");
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    // ── default_injection ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_scenario_default_dirac() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: Dirac\n  time: 5.0\n  amount: 0.1\n";
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        load_scenario(f.path().to_str().unwrap(), &mut model).unwrap();
+
+        // Dirac at t=5 → non-zero at peak
+        assert!(model.injection().evaluate(5.0) > 0.0);
+    }
+
+    #[test]
+    fn test_load_scenario_default_gaussian() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: Gaussian\n  center: 10.0\n  width: 3.0\n  peak_concentration: 0.1\n";
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        load_scenario(f.path().to_str().unwrap(), &mut model).unwrap();
+        assert!(model.injection().evaluate(10.0) > 0.0);
+    }
+
+    #[test]
+    fn test_load_scenario_default_rectangle() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: Rectangle\n  start: 0.0\n  end: 10.0\n  concentration: 0.5\n";
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        load_scenario(f.path().to_str().unwrap(), &mut model).unwrap();
+        assert!(model.injection().evaluate(5.0) > 0.0);
+        assert_eq!(model.injection().evaluate(15.0), 0.0);
+    }
+
+    #[test]
+    fn test_load_scenario_default_none() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: None\n";
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        load_scenario(f.path().to_str().unwrap(), &mut model).unwrap();
+        assert_eq!(model.injection().evaluate(0.0), 0.0);
+    }
+
+    // ── per-species injections ────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_scenario_per_species_override() {
+        use crate::models::{LangmuirMulti, SpeciesParams};
+
+        let sp_a = SpeciesParams::new("A", 1.0, 0.5, 1, TemporalInjection::none());
+        let sp_b = SpeciesParams::new("B", 1.0, 2.0, 1, TemporalInjection::none());
+        let mut model = LangmuirMulti::new(vec![sp_a, sp_b], 50, 0.4, 0.001, 0.25).unwrap();
+
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: None\ninjections:\n  - species: B\n    type: Dirac\n    time: 5.0\n    amount: 0.1\n";
+        let f = tmp_yaml(yaml);
+        load_scenario(f.path().to_str().unwrap(), &mut model).unwrap();
+
+        let params = model.species_params();
+        // A: still None
+        assert_eq!(params[0].injection.evaluate(5.0), 0.0);
+        // B: Dirac at t=5
+        assert!(params[1].injection.evaluate(5.0) > 0.0);
+    }
+
+    #[test]
+    fn test_load_scenario_per_species_unknown_name() {
+        use crate::models::{LangmuirMulti, SpeciesParams};
+
+        let sp = SpeciesParams::new("A", 1.0, 0.5, 1, TemporalInjection::none());
+        let mut model = LangmuirMulti::new(vec![sp], 50, 0.4, 0.001, 0.25).unwrap();
+
+        let yaml = "initial_condition: zero\ninjections:\n  - species: Unknown\n    type: None\n";
+        let f = tmp_yaml(yaml);
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    // ── injection parse errors ────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_scenario_unknown_injection_type() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: Step\n";
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    #[test]
+    fn test_load_scenario_dirac_missing_field() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  type: Dirac\n  time: 5.0\n";
+        // "amount" is missing
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    #[test]
+    fn test_load_scenario_injection_missing_type() {
+        let yaml = "initial_condition: zero\ndefault_injection:\n  center: 5.0\n";
+        let f = tmp_yaml(yaml);
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    // ── format / I/O errors ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_scenario_json_format() {
+        let json = r#"{"initial_condition":"zero","default_injection":{"type":"None"}}"#;
+        let f = tmp_json(json);
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_load_scenario_file_not_found() {
+        let mut model = single_model();
+        let result = load_scenario("/tmp/does_not_exist_chrom_rs_scenario.yml", &mut model);
+        assert!(matches!(result, Err(ConfigError::Io(_))));
+    }
+
+    #[test]
+    fn test_load_scenario_invalid_yaml() {
+        let f = tmp_yaml("not: valid: yaml: [");
+        let mut model = single_model();
+        let result = load_scenario(f.path().to_str().unwrap(), &mut model);
+        assert!(matches!(result, Err(ConfigError::Parse(_))));
+    }
+}

--- a/src/config/scenario.rs
+++ b/src/config/scenario.rs
@@ -32,11 +32,13 @@
 //!
 //! # Design note
 //!
-//! This loader does **not** deserialise into an intermediate struct.
-//! It reads the YAML/JSON fields, constructs [`TemporalInjection`] values
-//! directly, and applies them to the model via [`PhysicalModel::set_default_injection`]
-//! and [`PhysicalModel::set_injection_for_species`]. The result is a fully
-//! initialised [`DomainBoundaries`] built from `initial_condition`.
+//! This loader does **not** deserialize into an intermediate struct.
+//! It reads the YAML/JSON fields, constructs
+//! [`TemporalInjection`](crate::models::TemporalInjection) values directly,
+//! and applies them to the model via the `PhysicalModel` injection setters.
+//! The result is a fully initialized
+//! [`DomainBoundaries`](crate::solver::DomainBoundaries) built from
+//! `initial_condition`.
 
 use crate::config::{ConfigError, Format, format_from_path};
 use crate::models::TemporalInjection;

--- a/src/config/solver.rs
+++ b/src/config/solver.rs
@@ -1,4 +1,4 @@
-//! Loader for `solver.yml` / `solver.json` (DD-015).
+//! Loader for `solver.yml` / `solver.json`.
 //!
 //! `solver.yml` defines **how** to solve the scenario: numerical method,
 //! time discretisation, and optional trajectory subsampling.
@@ -48,7 +48,9 @@ struct SolverFile {
     /// Number of time steps $N_t$.
     time_steps: usize,
 
-    /// Trajectory subsampling interval (DD-010 / DD-015).
+    /// Trajectory subsampling interval.
+    ///
+    /// You can save the results of the calculations at each step in the JSON export.
     ///
     /// `null` or absent → full trajectory. `N` → every N-th step kept.
     #[serde(default)]

--- a/src/config/solver.rs
+++ b/src/config/solver.rs
@@ -12,15 +12,17 @@
 //! step: null         # null = full trajectory; integer N = every N-th step
 //! ```
 //!
-//! The file is deserialised directly into [`SolverConfiguration`] via serde.
-//! The `type` field is mapped to [`SolverType::TimeEvolution`].
+//! The file is deserialised directly into
+//! [`SolverConfiguration`](crate::solver::SolverConfiguration) via serde.
+//! The `type` field is mapped to
+//! [`SolverType::TimeEvolution`](crate::solver::SolverType::TimeEvolution).
 //!
 //! # Supported solver types
 //!
 //! | YAML `type` | Maps to |
 //! |---|---|
-//! | `RK4` | `SolverType::TimeEvolution` dispatched to [`RK4Solver`] |
-//! | `Euler` | `SolverType::TimeEvolution` dispatched to [`EulerSolver`] |
+//! | `RK4` | `SolverType::TimeEvolution` dispatched to [`RK4Solver`](crate::solver::RK4Solver) |
+//! | `Euler` | `SolverType::TimeEvolution` dispatched to [`EulerSolver`](crate::solver::EulerSolver) |
 //!
 //! The solver name is stored as metadata in `SimulationResult` after the run.
 //! The CLI selects the concrete solver implementation based on this field.

--- a/src/config/solver.rs
+++ b/src/config/solver.rs
@@ -1,0 +1,257 @@
+//! Loader for `solver.yml` / `solver.json` (DD-015).
+//!
+//! `solver.yml` defines **how** to solve the scenario: numerical method,
+//! time discretisation, and optional trajectory subsampling.
+//!
+//! # File format
+//!
+//! ```yaml
+//! type: RK4          # or Euler
+//! total_time: 600.0
+//! time_steps: 10000
+//! step: null         # null = full trajectory; integer N = every N-th step
+//! ```
+//!
+//! The file is deserialised directly into [`SolverConfiguration`] via serde.
+//! The `type` field is mapped to [`SolverType::TimeEvolution`].
+//!
+//! # Supported solver types
+//!
+//! | YAML `type` | Maps to |
+//! |---|---|
+//! | `RK4` | `SolverType::TimeEvolution` dispatched to [`RK4Solver`] |
+//! | `Euler` | `SolverType::TimeEvolution` dispatched to [`EulerSolver`] |
+//!
+//! The solver name is stored as metadata in `SimulationResult` after the run.
+//! The CLI selects the concrete solver implementation based on this field.
+
+use crate::config::{ConfigError, load_from_file};
+use crate::solver::SolverConfiguration;
+
+// ============================================================================
+// SolverFile — intermediate deserialisation struct
+// ============================================================================
+
+/// Flat representation of `solver.yml` / `solver.json`.
+///
+/// Deserialised from the file, then converted to [`SolverConfiguration`] +
+/// a solver name string used by the CLI to select the concrete solver.
+#[derive(Debug, serde::Deserialize)]
+struct SolverFile {
+    /// Solver algorithm name: `"RK4"` or `"Euler"`.
+    #[serde(rename = "type")]
+    solver_type: String,
+
+    /// Total simulation time $T$ **\[s\]**.
+    total_time: f64,
+
+    /// Number of time steps $N_t$.
+    time_steps: usize,
+
+    /// Trajectory subsampling interval (DD-010 / DD-015).
+    ///
+    /// `null` or absent → full trajectory. `N` → every N-th step kept.
+    #[serde(default)]
+    step: Option<usize>,
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+/// Output of [`load_solver`]: the solver configuration and the algorithm name.
+pub struct SolverConfig {
+    /// Numerical integration parameters.
+    pub config: SolverConfiguration,
+
+    /// Solver algorithm name as written in `solver.yml` (`"RK4"` or `"Euler"`).
+    ///
+    /// Used by the CLI to instantiate the correct [`Solver`](crate::solver::Solver)
+    /// implementation.
+    pub solver_name: String,
+}
+
+/// Loads a solver configuration from a file.
+///
+/// # Errors
+///
+/// - [`ConfigError::Io`] if the file cannot be read.
+/// - [`ConfigError::UnsupportedFormat`] if the extension is not recognised.
+/// - [`ConfigError::Parse`] if the content is not valid YAML/JSON.
+/// - [`ConfigError::Validation`] if:
+///   - `total_time` ≤ 0.
+///   - `time_steps` = 0.
+///   - `type` is not `"RK4"` or `"Euler"`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use chrom_rs::config::solver::load_solver;
+///
+/// let sc = load_solver("solver_rk4.yml").unwrap();
+/// println!("solver: {}, step: {:?}", sc.solver_name, sc.config.step);
+/// ```
+pub fn load_solver(path: &str) -> Result<SolverConfig, ConfigError> {
+    let raw: SolverFile = load_from_file(path)?;
+
+    // Validate solver type
+    if raw.solver_type != "RK4" && raw.solver_type != "Euler" {
+        return Err(ConfigError::Validation(format!(
+            "unknown solver type '{}' (expected 'RK4' or 'Euler')",
+            raw.solver_type
+        )));
+    }
+
+    // Validate numerical parameters
+    if raw.total_time <= 0.0 {
+        return Err(ConfigError::Validation(format!(
+            "total_time must be > 0, got {}",
+            raw.total_time
+        )));
+    }
+
+    if raw.time_steps == 0 {
+        return Err(ConfigError::Validation("time_steps must be > 0".into()));
+    }
+
+    let mut config = SolverConfiguration::time_evolution(raw.total_time, raw.time_steps);
+    if let Some(n) = raw.step {
+        config = config.with_step(n);
+    }
+
+    Ok(SolverConfig {
+        config,
+        solver_name: raw.solver_type,
+    })
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn tmp_yaml(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".yml").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    fn tmp_json(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::Builder::new().suffix(".json").tempfile().unwrap();
+        write!(f, "{content}").unwrap();
+        f
+    }
+
+    const RK4_YAML: &str = "\
+type: RK4
+total_time: 600.0
+time_steps: 10000
+step: null
+";
+
+    const EULER_YAML: &str = "\
+type: Euler
+total_time: 300.0
+time_steps: 5000
+";
+
+    // ── Success paths ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_load_rk4_yaml() {
+        let f = tmp_yaml(RK4_YAML);
+        let sc = load_solver(f.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(sc.solver_name, "RK4");
+        assert!(sc.config.validate().is_ok());
+        assert!(sc.config.step.is_none());
+    }
+
+    #[test]
+    fn test_load_euler_yaml() {
+        let f = tmp_yaml(EULER_YAML);
+        let sc = load_solver(f.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(sc.solver_name, "Euler");
+        assert!(sc.config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_load_with_step() {
+        let yaml = "type: RK4\ntotal_time: 600.0\ntime_steps: 10000\nstep: 50\n";
+        let f = tmp_yaml(yaml);
+        let sc = load_solver(f.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(sc.config.step, Some(50));
+    }
+
+    #[test]
+    fn test_load_json_format() {
+        let json = r#"{"type":"RK4","total_time":600.0,"time_steps":10000}"#;
+        let f = tmp_json(json);
+        let sc = load_solver(f.path().to_str().unwrap()).unwrap();
+
+        assert_eq!(sc.solver_name, "RK4");
+        assert!(sc.config.step.is_none());
+    }
+
+    #[test]
+    fn test_load_step_absent_defaults_to_none() {
+        // No step field → None
+        let yaml = "type: Euler\ntotal_time: 100.0\ntime_steps: 1000\n";
+        let f = tmp_yaml(yaml);
+        let sc = load_solver(f.path().to_str().unwrap()).unwrap();
+        assert!(sc.config.step.is_none());
+    }
+
+    // ── Validation errors ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_unknown_solver_type() {
+        let yaml = "type: Adams\ntotal_time: 600.0\ntime_steps: 10000\n";
+        let f = tmp_yaml(yaml);
+        let result = load_solver(f.path().to_str().unwrap());
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    #[test]
+    fn test_negative_total_time() {
+        let yaml = "type: RK4\ntotal_time: -1.0\ntime_steps: 1000\n";
+        let f = tmp_yaml(yaml);
+        let result = load_solver(f.path().to_str().unwrap());
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    #[test]
+    fn test_zero_time_steps() {
+        let yaml = "type: RK4\ntotal_time: 600.0\ntime_steps: 0\n";
+        let f = tmp_yaml(yaml);
+        let result = load_solver(f.path().to_str().unwrap());
+        assert!(matches!(result, Err(ConfigError::Validation(_))));
+    }
+
+    // ── I/O and format errors ─────────────────────────────────────────────────
+
+    #[test]
+    fn test_file_not_found() {
+        let result = load_solver("/tmp/does_not_exist_chrom_rs_solver.yml");
+        assert!(matches!(result, Err(ConfigError::Io(_))));
+    }
+
+    #[test]
+    fn test_unsupported_extension() {
+        let result = load_solver("solver.toml");
+        assert!(matches!(result, Err(ConfigError::UnsupportedFormat(_))));
+    }
+
+    #[test]
+    fn test_invalid_yaml_syntax() {
+        let f = tmp_yaml("not: valid: yaml: [");
+        let result = load_solver(f.path().to_str().unwrap());
+        assert!(matches!(result, Err(ConfigError::Parse(_))));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,20 @@
 //! chrom-rs: Chromatography Simulation Framework
 //!
-//! A flexible and extensible framework for simulating chromatographic processes
-//! using numerical methods. Built with Rust for performance and safety.
+//! A flexible and extensible framework for simulating liquid chromatographic
+//! processes using numerical methods. Built with Rust for performance and safety.
 //!
 //! # Architecture
 //!
 //! chrom-rs is built on two core principles:
 //!
-//! 1. **Separation of Physics and Numerics**
-//!    - Physical models define equations (what to solve)
-//!    - Numerical solvers provide methods (how to solve)
+//! 1. **Separation of physics and numerics** — physical models define the
+//!    equations (what to solve); numerical solvers provide the integration
+//!    method (how to solve them). The same model can be solved with any
+//!    solver, and the same solver can integrate any model.
 //!
-//! 2. **Extensibility and Type Safety**
-//!    - Trait-based design for easy extension
-//!    - Type-safe state management
-//!    - Stable API (v0.1.0+)
+//! 2. **Extensibility and type safety** — all extension points are traits;
+//!    state is managed through typed containers; the API is stable from
+//!    v0.1.0 onwards.
 //!
 //! # Quick Start
 //!
@@ -61,30 +61,70 @@
 //!
 //! # Modules
 //!
-//! - [`physics`]: Physical models (equations)
-//! - [`solver`]: Numerical solvers (methods)
-//! - [`cli`]: Command-line interface
-//! - [`output`]: Result visualization and export (publishing)
+//! | Module | Role |
+//! |--------|------|
+//! | [`physics`] | Core traits and data types for physical models |
+//! | [`models`] | Concrete chromatography models (Langmuir single and multi-species) |
+//! | [`solver`] | Numerical solvers, scenario definition, and simulation result |
+//! | [`config`] | YAML/JSON configuration file loaders |
+//! | [`output`] | CSV export, JSON export, and chromatogram visualisation |
+//! | [`cli`] | Command-line interface built on `dynamic-cli` |
+//! | [`prelude`] | Convenience re-exports for the most common types |
 
-// Core modules
+/// Physical model traits, state containers, and data types.
+///
+/// Defines the extension points that all physical models must implement,
+/// as well as the typed containers ([`physics::PhysicalState`],
+/// [`physics::PhysicalData`]) used to exchange state between models and
+/// solvers.
 pub mod physics;
 
+/// Concrete chromatography models.
+///
+/// Contains [`models::LangmuirSingle`] for single-species simulations and
+/// [`models::LangmuirMulti`] for competitive multi-species adsorption, along
+/// with the [`models::TemporalInjection`] type that defines inlet boundary
+/// conditions as a function of time.
 pub mod models;
+
+/// Numerical solvers and simulation infrastructure.
+///
+/// Provides [`solver::Solver`] implementations (Forward Euler, RK4), the
+/// [`solver::Scenario`] type that binds a model to its boundary conditions,
+/// [`solver::SolverConfiguration`] for numerical parameters, and
+/// [`solver::SimulationResult`] which holds the computed trajectory.
 pub mod solver;
 
+/// Result visualisation and data export.
+///
+/// Sub-modules cover CSV export, JSON export, and chromatogram plots via
+/// `plotters`. See [`output::export`] and [`output::visualization`].
 pub mod output;
 
+/// Configuration file loaders for the three-file layout.
+///
+/// Each loader reads one YAML or JSON file and returns the corresponding
+/// domain object: [`config::model::load_model`] → `Box<dyn PhysicalModel>`,
+/// [`config::scenario::load_scenario`] → [`solver::DomainBoundaries`],
+/// [`config::solver::load_solver`] → [`solver::SolverConfiguration`].
 pub mod config;
 
+/// Command-line interface.
+///
+/// Entry point is [`cli::build_app`], which assembles the `dynamic-cli`
+/// application from the embedded `commands.yml` declaration and wires
+/// [`cli::app::RunHandler`] to the simulation pipeline.
 pub mod cli;
 
+/// Convenient re-exports for the most commonly used types.
+///
+/// Import everything with `use chrom_rs::prelude::*` to get the core traits
+/// and types without writing long paths.
+///
+/// ```rust
+/// use chrom_rs::prelude::*;
+/// ```
 pub mod prelude {
-    //! Convenient imports for common usage
-    //!
-    //! ```rust
-    //!
-    //! use chrom_rs::prelude::*;
-    //! ```
     pub use crate::models::TemporalInjection;
     pub use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
     pub use crate::solver::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@
 //!
 //! - [`physics`]: Physical models (equations)
 //! - [`solver`]: Numerical solvers (methods)
-//! - `cli`: Command-line interface (optional)
+//! - [`cli`]: Command-line interface
 //! - [`output`]: Result visualization and export (publishing)
 
 // Core modules
@@ -75,6 +75,8 @@ pub mod solver;
 pub mod output;
 
 pub mod config;
+
+pub mod cli;
 
 pub mod prelude {
     //! Convenient imports for common usage

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,8 @@ pub mod solver;
 
 pub mod output;
 
+pub mod config;
+
 pub mod prelude {
     //! Convenient imports for common usage
     //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,25 @@
+//! # chrom-rs — binary entry point
+//!
+//! Delegates entirely to the [`cli`](chrom_rs::cli) layer built on
+//! `dynamic-cli`. All simulation logic lives in the library crate.
+//!
+//! # Usage
+//!
+//! ```text
+//! chrom-rs run --model model.yml --scenario scenario.yml --solver solver.yml
+//!              [--project-dir <dir>]
+//!              [--output-csv results.csv]
+//!              [--output-plot chromatogram.png]
+//!              [--export-json results.json]
+//! ```
+
+fn main() {
+    let result = chrom_rs::cli::build_app()
+        .map_err(|e| format!("initialisation error: {e}"))
+        .and_then(|app| app.run().map_err(|e| format!("runtime error: {e}")));
+
+    if let Err(e) = result {
+        eprintln!("chrom-rs: {e}");
+        std::process::exit(1);
+    }
+}

--- a/src/models/injection.rs
+++ b/src/models/injection.rs
@@ -71,6 +71,24 @@ enum TemporalInjectionSnapshot {
     None,
 }
 
+/// Temporal injection profile at the column inlet ($z = 0$).
+///
+/// Defines how the inlet concentration $C(t, z=0)$ varies over time.
+/// The solver evaluates the profile at each time step and applies it as
+/// a boundary condition.
+///
+/// All variants except [`TemporalInjection::Custom`] are serialisable and
+/// can be specified in `scenario.yml`.
+///
+/// # Choosing a profile
+///
+/// | Variant | Use case |
+/// |---------|----------|
+/// | [`Dirac`](TemporalInjection::Dirac) | Instantaneous pulse (sharp injection) |
+/// | [`Gaussian`](TemporalInjection::Gaussian) | Smooth finite-width pulse |
+/// | [`Rectangle`](TemporalInjection::Rectangle) | Constant-concentration step injection |
+/// | [`Custom`](TemporalInjection::Custom) | Arbitrary closure (not serialisable) |
+/// | [`None`](TemporalInjection::None) | No injection (zero inlet concentration) |
 pub enum TemporalInjection {
     /// Dirac delta injection at a single time point
     ///
@@ -230,7 +248,7 @@ impl std::fmt::Debug for TemporalInjection {
 
 // ==================== Manual Serialize Implementation ====================
 
-/// Serialises [`TemporalInjection`] to JSON/YAML via [`TemporalInjectionSnapshot`].
+/// Serialises [`TemporalInjection`] to JSON/YAML via an internal snapshot type.
 ///
 /// # Errors
 ///
@@ -277,7 +295,7 @@ impl Serialize for TemporalInjection {
 
 // ==================== Manual Deserialize Implementation ====================
 
-/// Deserializes [`TemporalInjection`] from JSON/YAML via [`TemporalInjectionSnapshot`].
+/// Deserializes [`TemporalInjection`] from JSON/YAML via an internal snapshot type.
 ///
 /// [`TemporalInjection::Custom`] cannot be deserialized — it must be constructed
 /// programmatically via [`TemporalInjection::custom`].

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -450,22 +450,50 @@ impl LangmuirMulti {
     }
 
     /// Returns the current number of species in the model
+    /// Returns the current number of chemical species in the model.
+    ///
+    /// Grows by one on each successful call to [`add_species`](Self::add_species).
     pub fn n_species(&self) -> usize {
         self.species.len()
     }
 
+    /// Returns the extra-granular porosity $\varepsilon$ **\[dimensionless\]**.
+    ///
+    /// Defined at construction; constant over the simulation lifetime.
+    /// Used to derive $F_e = (1-\varepsilon)/\varepsilon$ and $u_e = u/\varepsilon$.
     pub fn porosity(&self) -> f64 {
         self.porosity
     }
+
+    /// Returns the superficial velocity $u$ **\[m/s\]**.
+    ///
+    /// The interstitial velocity $u_e = u / \varepsilon$ is precomputed and stored
+    /// separately; this accessor returns the raw constructor argument.
     pub fn velocity(&self) -> f64 {
         self.velocity
     }
+
+    /// Returns the column length $L$ **\[m\]**.
+    ///
+    /// The spatial step $\Delta z = L / N_z$ is precomputed at construction.
     pub fn column_length(&self) -> f64 {
         self.column_length
     }
+
+    /// Returns the number of spatial discretisation points $N_z$.
+    ///
+    /// Matches the number of rows in the concentration state matrix
+    /// `[n_points × n_species]`. Must be $\geq 2$ (enforced by the constructor).
     pub fn spatial_points(&self) -> usize {
         self.n_points
     }
+
+    /// Returns all species parameter sets in insertion order.
+    ///
+    /// The slice index matches the column index of the state matrix
+    /// `[n_points × n_species]` — same order as [`species_names`](Self::species_names).
+    /// Use this accessor when full parameter detail is needed; prefer
+    /// [`species_names`](Self::species_names) for display purposes only.
     pub fn species_params(&self) -> &[SpeciesParams] {
         &self.species
     }
@@ -563,6 +591,10 @@ impl LangmuirMulti {
 #[typetag::serde]
 impl PhysicalModel for LangmuirMulti {
     /// Returns the number of spatial discretization points (row dimension of the state matrix)
+    /// Returns the total number of state variables — `n_points × n_species`.
+    ///
+    /// This is the flattened size of the concentration matrix, used by the
+    /// solver to determine step sizes and parallelism thresholds.
     fn points(&self) -> usize {
         self.n_points
     }
@@ -776,10 +808,19 @@ impl PhysicalModel for LangmuirMulti {
         )
     }
 
+    /// Returns the human-readable model identifier.
+    ///
+    /// Used as the `"model"` key in the JSON export map (DD-010) and in
+    /// simulation result metadata.
     fn name(&self) -> &str {
         "Langmuir Multi-Species"
     }
 
+    /// Returns a brief description of the model's physical assumptions.
+    ///
+    /// Documents the competitive Langmuir isotherm, the upwind spatial scheme,
+    /// and the matrix Jacobian inversion at the heart of the multi-species
+    /// transport computation.
     fn description(&self) -> Option<&str> {
         Some(
             "Competitive Langmuir adsorption model for n species \
@@ -1455,5 +1496,143 @@ mod tests {
     #[test]
     fn test_description_is_some() {
         assert!(single_model().description().is_some());
+    }
+
+    // ── Exportable ────────────────────────────────────────────────────────────
+
+    /// Builds a minimal trajectory (3 steps, all-zero concentrations) suitable
+    /// for exercising `to_map` without running a full simulation.
+    fn make_trajectory(model: &LangmuirMulti) -> (Vec<f64>, Vec<PhysicalState>) {
+        let state = model.setup_initial_state();
+        let time_points = vec![0.0, 0.5, 1.0];
+        let trajectory = vec![state.clone(), state.clone(), state.clone()];
+        (time_points, trajectory)
+    }
+
+    #[test]
+    fn test_to_map_species_blocks() {
+        let model = two_species_model();
+        let (tp, traj) = make_trajectory(&model);
+        let map = model.to_map(&tp, &traj, &HashMap::new());
+
+        let profiles = &map["data"]["profiles"];
+        assert!(
+            profiles.get("species_0").is_some(),
+            "species_0 block missing"
+        );
+        assert!(
+            profiles.get("species_1").is_some(),
+            "species_1 block missing"
+        );
+
+        // name must be colocated with the concentration data (DD-010 invariant)
+        assert_eq!(profiles["species_0"]["name"].as_str().unwrap(), "A");
+        assert_eq!(profiles["species_1"]["name"].as_str().unwrap(), "B");
+
+        let conc0 = profiles["species_0"]["Concentration"].as_array().unwrap();
+        assert_eq!(
+            conc0.len(),
+            tp.len(),
+            "species_0 Concentration length mismatch"
+        );
+    }
+
+    #[test]
+    fn test_to_map_global_block_present_and_empty() {
+        // The global block is the extension point for future scalar/vector quantities.
+        // It must be present even when all data is in species_N blocks (Matrix dispatch).
+        let model = single_model();
+        let (tp, traj) = make_trajectory(&model);
+        let map = model.to_map(&tp, &traj, &HashMap::new());
+
+        let profiles = map["data"]["profiles"].as_object().unwrap();
+        assert!(
+            profiles.contains_key("global"),
+            "global extension block missing"
+        );
+        assert!(
+            profiles["global"].as_object().unwrap().is_empty(),
+            "global block must be empty for Matrix data"
+        );
+    }
+
+    #[test]
+    fn test_to_map_metadata_species_array() {
+        let model = two_species_model();
+        let (tp, traj) = make_trajectory(&model);
+        let map = model.to_map(&tp, &traj, &HashMap::new());
+
+        let meta = map["metadata"].as_object().unwrap();
+        assert_eq!(meta["n_species"].as_u64().unwrap(), 2);
+
+        let species_arr = meta["species"].as_array().unwrap();
+        assert_eq!(species_arr.len(), 2, "species array length mismatch");
+        assert_eq!(species_arr[0]["name"].as_str().unwrap(), "A");
+        assert_eq!(species_arr[1]["name"].as_str().unwrap(), "B");
+        assert!((species_arr[0]["lambda"].as_f64().unwrap() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_from_map_round_trip() {
+        let original = two_species_model();
+        let (tp, traj) = make_trajectory(&original);
+        let map = original.to_map(&tp, &traj, &HashMap::new());
+
+        let reconstructed = LangmuirMulti::from_map(map).expect("from_map must succeed");
+
+        assert_eq!(reconstructed.n_species(), original.n_species());
+        assert_eq!(reconstructed.spatial_points(), original.spatial_points());
+        assert!((reconstructed.porosity() - original.porosity()).abs() < 1e-12);
+        assert!((reconstructed.velocity() - original.velocity()).abs() < 1e-12);
+        assert!((reconstructed.column_length() - original.column_length()).abs() < 1e-12);
+
+        // Species names must survive the round-trip (order preserved)
+        assert_eq!(reconstructed.species_names(), original.species_names());
+    }
+
+    #[test]
+    fn test_from_map_species_count_mismatch() {
+        use serde_json::json;
+        let map = json!({
+            "metadata": {
+                "nz": 100, "porosity": 0.4, "velocity": 0.001, "length": 0.25,
+                "species": []
+            }
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        assert!(
+            matches!(
+                LangmuirMulti::from_map(map),
+                Err(ExportError::SpeciesCountMismatch { .. })
+            ),
+            "Empty species array must yield SpeciesCountMismatch"
+        );
+    }
+
+    #[test]
+    fn test_from_map_missing_key() {
+        use serde_json::json;
+
+        // "porosity" absent — all other required keys present
+        let map = json!({
+            "metadata": {
+                "nz": 100, "velocity": 0.001, "length": 0.25,
+                "species": [{"name": "A", "lambda": 1.0, "langmuir_k": 0.5, "port_number": 1}]
+            }
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        assert!(
+            matches!(
+                LangmuirMulti::from_map(map),
+                Err(ExportError::MissingKey(_))
+            ),
+            "Missing 'porosity' must yield MissingKey"
+        );
     }
 }

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -452,7 +452,7 @@ impl LangmuirMulti {
     /// Applies the same injection profile to **all** species.
     ///
     /// Used by the config loader when `scenario.yml` defines only a
-    /// `default_injection` with no per-species override (DD-015).
+    /// `default_injection` with no per-species override.
     ///
     /// # Example
     ///
@@ -473,7 +473,7 @@ impl LangmuirMulti {
     /// Replaces the injection profile for a single species identified by name.
     ///
     /// Used by the config loader when `scenario.yml` lists per-species overrides
-    /// in the `injections` array (DD-015). Species not listed keep the profile
+    /// in the `injections` array. Species not listed keep the profile
     /// set by [`set_injection_all`](Self::set_injection_all).
     ///
     /// # Errors
@@ -867,7 +867,7 @@ impl PhysicalModel for LangmuirMulti {
 
     /// Returns the human-readable model identifier.
     ///
-    /// Used as the `"model"` key in the JSON export map (DD-010) and in
+    /// Used as the `"model"` key in the JSON export map and in
     /// simulation result metadata.
     fn name(&self) -> &str {
         "Langmuir Multi-Species"
@@ -1683,7 +1683,7 @@ mod tests {
             "species_1 block missing"
         );
 
-        // name must be colocated with the concentration data (DD-010 invariant)
+        // name must be colocated with the concentration data
         assert_eq!(profiles["species_0"]["name"].as_str().unwrap(), "A");
         assert_eq!(profiles["species_1"]["name"].as_str().unwrap(), "B");
 

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -884,6 +884,28 @@ impl PhysicalModel for LangmuirMulti {
              with upwind spatial discretisation and matrix Jacobian inversion.",
         )
     }
+
+    fn set_injections(
+        &mut self,
+        injections: &HashMap<Option<String>, TemporalInjection>,
+    ) -> Result<(), String> {
+        // Step 1 — apply the default injection to all species.
+        // This establishes the baseline before per-species overrides.
+        let default_key: Option<String> = None;
+        if let Some(inj) = injections.get(&default_key) {
+            self.set_injection_all(inj.clone());
+        }
+
+        // Step 2 — apply per-species overrides.
+        // Order within the HashMap is not guaranteed, but each named species
+        // is independent, so ordering does not matter.
+        for (key, inj) in injections {
+            if let Some(name) = key {
+                self.set_injection_for(name, inj.clone())?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Exportable for LangmuirMulti {

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -449,6 +449,63 @@ impl LangmuirMulti {
         Ok(())
     }
 
+    /// Applies the same injection profile to **all** species.
+    ///
+    /// Used by the config loader when `scenario.yml` defines only a
+    /// `default_injection` with no per-species override (DD-015).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::models::{LangmuirMulti, SpeciesParams, TemporalInjection};
+    ///
+    /// let sp = SpeciesParams::new("A", 1.0, 0.5, 1, TemporalInjection::none());
+    /// let mut model = LangmuirMulti::new(vec![sp], 100, 0.4, 0.001, 0.25).unwrap();
+    ///
+    /// model.set_injection_all(TemporalInjection::dirac(5.0, 0.1));
+    /// ```
+    pub fn set_injection_all(&mut self, injection: TemporalInjection) {
+        for sp in &mut self.species {
+            sp.injection = injection.clone();
+        }
+    }
+
+    /// Replaces the injection profile for a single species identified by name.
+    ///
+    /// Used by the config loader when `scenario.yml` lists per-species overrides
+    /// in the `injections` array (DD-015). Species not listed keep the profile
+    /// set by [`set_injection_all`](Self::set_injection_all).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if no species with the given name exists in the model.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::models::{LangmuirMulti, SpeciesParams, TemporalInjection};
+    ///
+    /// let sp_a = SpeciesParams::new("A", 1.0, 0.5, 1, TemporalInjection::none());
+    /// let sp_b = SpeciesParams::new("B", 1.0, 2.0, 1, TemporalInjection::none());
+    /// let mut model = LangmuirMulti::new(vec![sp_a, sp_b], 100, 0.4, 0.001, 0.25).unwrap();
+    ///
+    /// model.set_injection_all(TemporalInjection::dirac(5.0, 0.1));
+    /// model.set_injection_for("B", TemporalInjection::gaussian(10.0, 3.0, 0.05)).unwrap();
+    /// ```
+    pub fn set_injection_for(
+        &mut self,
+        species: &str,
+        injection: TemporalInjection,
+    ) -> Result<(), String> {
+        match self.species.iter_mut().find(|sp| sp.name == species) {
+            Some(sp) => {
+                sp.injection = injection;
+                Ok(())
+            }
+            None => Err(format!("Species '{species}' not found in model")),
+        }
+    }
+
     /// Returns the current number of species in the model
     /// Returns the current number of chemical species in the model.
     ///
@@ -1496,6 +1553,85 @@ mod tests {
     #[test]
     fn test_description_is_some() {
         assert!(single_model().description().is_some());
+    }
+
+    // ── set_injection_all / set_injection_for ─────────────────────────────────
+
+    #[test]
+    fn test_set_injection_all_applies_to_every_species() {
+        let mut model = two_species_model();
+        model.set_injection_all(TemporalInjection::dirac(5.0, 0.1));
+
+        // Both species must return a non-zero value at t=5
+        for sp in model.species_params() {
+            assert!(
+                sp.injection.evaluate(5.0) > 0.0,
+                "Species '{}' must have non-zero injection at peak",
+                sp.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_injection_all_overwrites_previous_profile() {
+        let mut model = two_species_model();
+        // First: set all to gaussian
+        model.set_injection_all(TemporalInjection::gaussian(10.0, 3.0, 0.1));
+        // Then overwrite with none
+        model.set_injection_all(TemporalInjection::none());
+
+        for sp in model.species_params() {
+            assert!(
+                sp.injection.evaluate(10.0).abs() < 1e-15,
+                "Species '{}' injection must be none after overwrite",
+                sp.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_set_injection_for_targets_single_species() {
+        let mut model = two_species_model();
+        model.set_injection_all(TemporalInjection::none());
+        model
+            .set_injection_for("B", TemporalInjection::dirac(5.0, 0.1))
+            .unwrap();
+
+        // A must stay none
+        let sp_a = model
+            .species_params()
+            .iter()
+            .find(|s| s.name == "A")
+            .unwrap();
+        assert!(sp_a.injection.evaluate(5.0).abs() < 1e-15);
+
+        // B must be non-zero
+        let sp_b = model
+            .species_params()
+            .iter()
+            .find(|s| s.name == "B")
+            .unwrap();
+        assert!(sp_b.injection.evaluate(5.0) > 0.0);
+    }
+
+    #[test]
+    fn test_set_injection_for_unknown_species_returns_err() {
+        let mut model = single_model();
+        let result = model.set_injection_for("Unknown", TemporalInjection::none());
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Unknown"));
+    }
+
+    #[test]
+    fn test_set_injection_for_does_not_alter_physical_params() {
+        let mut model = two_species_model();
+        model
+            .set_injection_for("A", TemporalInjection::gaussian(10.0, 3.0, 0.1))
+            .unwrap();
+
+        assert_eq!(model.n_species(), 2);
+        assert_eq!(model.spatial_points(), 100);
+        assert!((model.porosity() - 0.4).abs() < 1e-15);
     }
 
     // ── Exportable ────────────────────────────────────────────────────────────

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -280,6 +280,26 @@ impl LangmuirSingle {
         &self.injection
     }
 
+    /// Replaces the injection profile at the column inlet ($z = 0$).
+    ///
+    /// Called by the config loader after deserialising `scenario.yml` (DD-015).
+    /// The model parameters (λ, K̃, N, geometry) are unchanged.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::models::{LangmuirSingle, TemporalInjection};
+    ///
+    /// let mut model = LangmuirSingle::new(
+    ///     1.2, 0.4, 2.0, 0.4, 0.001, 0.25, 100,
+    ///     TemporalInjection::none(),
+    /// );
+    /// model.set_injection(TemporalInjection::dirac(5.0, 0.1));
+    /// ```
+    pub fn set_injection(&mut self, injection: TemporalInjection) {
+        self.injection = injection;
+    }
+
     /// Returns the number of spatial discretisation points $N_z$
     pub fn spatial_points(&self) -> usize {
         self.nz
@@ -741,6 +761,48 @@ mod tests {
     fn test_invalid_points() {
         let injection = TemporalInjection::none();
         LangmuirSingle::new(1.2, 0.4, 2.0, 0.4, 0.001, 0.25, 1, injection);
+    }
+
+    // ── set_injection ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_set_injection_replaces_profile() {
+        let mut model = LangmuirSingle::new(
+            1.2,
+            0.4,
+            2.0,
+            0.4,
+            0.001,
+            0.25,
+            100,
+            TemporalInjection::none(),
+        );
+        // Before: none — evaluates to 0 at any time
+        assert!((model.injection().evaluate(5.0)).abs() < 1e-15);
+
+        model.set_injection(TemporalInjection::dirac(5.0, 0.1));
+
+        // After: Dirac at t=5 — non-zero at peak
+        assert!(model.injection().evaluate(5.0) > 0.0);
+    }
+
+    #[test]
+    fn test_set_injection_does_not_alter_physical_params() {
+        let mut model = LangmuirSingle::new(
+            1.2,
+            0.4,
+            2.0,
+            0.4,
+            0.001,
+            0.25,
+            100,
+            TemporalInjection::none(),
+        );
+        model.set_injection(TemporalInjection::gaussian(10.0, 3.0, 0.1));
+
+        // Physical parameters must be unchanged after set_injection
+        assert_eq!(model.spatial_points(), 100);
+        assert!((model.length() - 0.25).abs() < 1e-15);
     }
 
     // ── Exportable ────────────────────────────────────────────────────────────

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -742,4 +742,138 @@ mod tests {
         let injection = TemporalInjection::none();
         LangmuirSingle::new(1.2, 0.4, 2.0, 0.4, 0.001, 0.25, 1, injection);
     }
+
+    // ── Exportable ────────────────────────────────────────────────────────────
+
+    /// Builds a minimal trajectory (3 steps, all-zero concentrations) suitable
+    /// for exercising `to_map` without running a full simulation.
+    fn make_trajectory(model: &LangmuirSingle) -> (Vec<f64>, Vec<PhysicalState>) {
+        let state = model.setup_initial_state();
+        let time_points = vec![0.0, 0.5, 1.0];
+        let trajectory = vec![state.clone(), state.clone(), state.clone()];
+        (time_points, trajectory)
+    }
+
+    #[test]
+    fn test_to_map_metadata_keys() {
+        let model = create_langmuir_single();
+        let (tp, traj) = make_trajectory(&model);
+        let map = model.to_map(&tp, &traj, &HashMap::new());
+
+        let meta = map["metadata"].as_object().unwrap();
+        for key in &[
+            "model",
+            "lambda",
+            "langmuir_k",
+            "port_number",
+            "length",
+            "nz",
+            "fe",
+            "ue",
+        ] {
+            assert!(meta.contains_key(*key), "Missing metadata key: {key}");
+        }
+        assert!((meta["lambda"].as_f64().unwrap() - 1.2).abs() < 1e-12);
+        assert!((meta["langmuir_k"].as_f64().unwrap() - 0.4).abs() < 1e-12);
+        assert_eq!(meta["nz"].as_u64().unwrap(), 100);
+    }
+
+    #[test]
+    fn test_to_map_data_structure() {
+        let model = create_langmuir_single();
+        let (tp, traj) = make_trajectory(&model);
+        let map = model.to_map(&tp, &traj, &HashMap::new());
+
+        let data = map["data"].as_object().unwrap();
+        assert!(
+            data.contains_key("time_points"),
+            "time_points block missing"
+        );
+        assert!(data.contains_key("profiles"), "profiles block missing");
+
+        let profiles = data["profiles"].as_object().unwrap();
+        assert!(
+            profiles.contains_key("species_0"),
+            "species_0 block missing"
+        );
+
+        let conc = profiles["species_0"]["Concentration"].as_array().unwrap();
+        assert_eq!(
+            conc.len(),
+            tp.len(),
+            "Concentration length must match time_points"
+        );
+    }
+
+    #[test]
+    fn test_to_map_solver_metadata_merged_but_not_overriding() {
+        let model = create_langmuir_single();
+        let (tp, traj) = make_trajectory(&model);
+
+        let mut solver_meta = HashMap::new();
+        solver_meta.insert("solver".to_string(), "RK4".to_string());
+        // "lambda" already set by the model — model value must win
+        solver_meta.insert("lambda".to_string(), "999.0".to_string());
+
+        let map = model.to_map(&tp, &traj, &solver_meta);
+        let meta = map["metadata"].as_object().unwrap();
+
+        assert_eq!(
+            meta["solver"].as_str().unwrap(),
+            "RK4",
+            "solver key must be merged"
+        );
+        assert!(
+            (meta["lambda"].as_f64().unwrap() - 1.2).abs() < 1e-12,
+            "model lambda must take precedence over solver metadata"
+        );
+    }
+
+    #[test]
+    fn test_from_map_round_trip() {
+        let original = create_langmuir_single();
+        let (tp, traj) = make_trajectory(&original);
+        let map = original.to_map(&tp, &traj, &HashMap::new());
+
+        let reconstructed = LangmuirSingle::from_map(map).expect("from_map must succeed");
+
+        assert_eq!(reconstructed.spatial_points(), original.spatial_points());
+        assert!((reconstructed.length() - original.length()).abs() < 1e-12);
+
+        // Second pass: derived quantities (fe, ue) must survive the back-computation
+        // porosity = 1/(1+fe), velocity = ue × ε
+        let map2 = reconstructed.to_map(&tp, &traj, &HashMap::new());
+        let meta2 = map2["metadata"].as_object().unwrap();
+        assert!((meta2["lambda"].as_f64().unwrap() - 1.2).abs() < 1e-12);
+        assert!((meta2["langmuir_k"].as_f64().unwrap() - 0.4).abs() < 1e-12);
+        assert!((meta2["fe"].as_f64().unwrap() - 1.5).abs() < 1e-9);
+        assert!((meta2["ue"].as_f64().unwrap() - 0.0025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_from_map_missing_key() {
+        use serde_json::json;
+
+        // Metadata block present but "lambda" absent
+        let partial = json!({"metadata": {"langmuir_k": 0.4}})
+            .as_object()
+            .cloned()
+            .unwrap();
+        assert!(
+            matches!(
+                LangmuirSingle::from_map(partial),
+                Err(ExportError::MissingKey(_))
+            ),
+            "Missing 'lambda' must yield MissingKey"
+        );
+
+        // No metadata block at all
+        assert!(
+            matches!(
+                LangmuirSingle::from_map(serde_json::Map::new()),
+                Err(ExportError::MissingKey(_))
+            ),
+            "Absent metadata block must yield MissingKey"
+        );
+    }
 }

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -282,7 +282,7 @@ impl LangmuirSingle {
 
     /// Replaces the injection profile at the column inlet ($z = 0$).
     ///
-    /// Called by the config loader after deserialising `scenario.yml` (DD-015).
+    /// Called by the config loader after deserializing `scenario.yml`.
     /// The model parameters (λ, K̃, N, geometry) are unchanged.
     ///
     /// # Example
@@ -300,7 +300,7 @@ impl LangmuirSingle {
         self.injection = injection;
     }
 
-    /// Returns the number of spatial discretisation points $N_z$
+    /// Returns the number of spatial discretization points $N_z$
     pub fn spatial_points(&self) -> usize {
         self.nz
     }

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -466,6 +466,19 @@ impl PhysicalModel for LangmuirSingle {
         Read from Physical State metadata.",
         )
     }
+
+    fn set_injections(
+        &mut self,
+        injections: &HashMap<Option<String>, TemporalInjection>,
+    ) -> Result<(), String> {
+        // Single-species: apply the default injection (None key) if present.
+        // Per-species keys are ignored — there is no named species to target.
+        let default_key: Option<String> = None;
+        if let Some(inj) = injections.get(&default_key) {
+            self.set_injection(inj.clone());
+        }
+        Ok(())
+    }
 }
 
 impl Exportable for LangmuirSingle {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,4 +1,4 @@
-//! Physical models for chromatography simulation
+//! Physical models for chromatography simulation.
 //!
 //! All models implement the [`PhysicalModel`](crate::physics::PhysicalModel) trait.
 //! The solver calls `compute_physics` at each time step — models are responsible
@@ -6,12 +6,12 @@
 //!
 //! # Available Models
 //!
-//! ## [`LangmuirSingle`] — single species
+//! ## [`LangmuirSingle`](crate::models::LangmuirSingle) — single species
 //!
 //! One chemical species transported through the column with a Langmuir isotherm.
 //! Use this model to study retention and peak shape for a pure compound.
 //!
-//! ## [`LangmuirMulti`] — multiple species with competitive adsorption
+//! ## [`LangmuirMulti`](crate::models::LangmuirMulti) — multiple species with competitive adsorption
 //!
 //! Two or more species competing for the same adsorption sites. The presence
 //! of one species reduces the capacity available to all others, producing the
@@ -19,24 +19,28 @@
 //!
 //! # Injection
 //!
-//! Both models use [`TemporalInjection`] to define how concentration enters
-//! the column at the inlet ($z = 0$) as a function of time. The solver writes
-//! the current time into the `PhysicalState` metadata before each call to
-//! `compute_physics`.
+//! Both models use [`TemporalInjection`](crate::models::TemporalInjection) to
+//! define how concentration enters the column at the inlet ($z = 0$) as a
+//! function of time. The solver writes the current time into the `PhysicalState`
+//! metadata before each call to `compute_physics`.
 
-// =================================================================================================
+// ================================================================================================
 // Module Declarations
-// =================================================================================================
+// ================================================================================================
 
-//mod langmuir_single_simple;
+/// Temporal injection profiles for inlet boundary conditions.
 pub mod injection;
-pub mod langmuir_multi;
-pub mod langmuir_single;
-// =================================================================================================
-// Public Re-exports
-// =================================================================================================
 
-//pub use langmuir_single_simple::LangmuirSingleSimple;
+/// Multi-species Langmuir chromatography model with competitive adsorption.
+pub mod langmuir_multi;
+
+/// Single-species Langmuir chromatography model.
+pub mod langmuir_single;
+
+// ================================================================================================
+// Public Re-exports
+// ================================================================================================
+
 pub use injection::TemporalInjection;
 pub use langmuir_multi::{LangmuirMulti, SpeciesParams};
 pub use langmuir_single::LangmuirSingle;

--- a/src/output/export/json.rs
+++ b/src/output/export/json.rs
@@ -27,7 +27,7 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use chrom_rs::output::export::json::{to_json, from_json};
+//! use chrom_rs::output::export::{to_json, from_json};
 //! use serde_json::{Map, Value, json};
 //!
 //! // Produced by model.to_map(...) in the CLI layer
@@ -104,7 +104,7 @@ impl From<serde_json::Error> for JsonError {
 /// Writes a JSON map to a file (pretty-printed).
 ///
 /// The map is typically produced by
-/// [`Exportable::to_map`](crate::physics::export::Exportable::to_map).
+/// [`Exportable::to_map`](crate::physics::Exportable::to_map).
 ///
 /// # Errors
 ///
@@ -115,7 +115,7 @@ impl From<serde_json::Error> for JsonError {
 /// # Example
 ///
 /// ```rust,no_run
-/// use chrom_rs::output::export::json::to_json;
+/// use chrom_rs::output::export::to_json;
 /// use serde_json::{Map, Value};
 ///
 /// let mut map = Map::new();
@@ -132,7 +132,7 @@ pub fn to_json(map: &Map<String, Value>, path: &str) -> Result<(), JsonError> {
 /// Reads a JSON file and returns its content as a generic map.
 ///
 /// The map can then be passed to
-/// [`Exportable::from_map`](crate::physics::export::Exportable::from_map)
+/// [`Exportable::from_map`](crate::physics::Exportable::from_map)
 /// to reconstruct a physical model.
 ///
 /// # Errors
@@ -144,7 +144,7 @@ pub fn to_json(map: &Map<String, Value>, path: &str) -> Result<(), JsonError> {
 /// # Example
 ///
 /// ```rust,no_run
-/// use chrom_rs::output::export::json::from_json;
+/// use chrom_rs::output::export::from_json;
 ///
 /// let map = from_json("/tmp/result.json");
 /// ```
@@ -195,11 +195,9 @@ mod tests {
         to_json(&original, path).expect("write");
         let loaded = from_json(path).expect("read");
 
-        // metadata.solver must survive the round-trip
         let solver = loaded["metadata"]["solver"].as_str().unwrap();
         assert_eq!(solver, "RK4");
 
-        // time_points must survive
         let tp = loaded["data"]["time_points"].as_array().unwrap();
         assert_eq!(tp.len(), 3);
         assert!((tp[1].as_f64().unwrap() - 1.0).abs() < 1e-12);
@@ -213,7 +211,6 @@ mod tests {
 
     #[test]
     fn test_from_json_not_object() {
-        // Write a JSON array — not a top-level object
         let path = "/tmp/chrom_rs_test_array.json";
         std::fs::write(path, "[1, 2, 3]").unwrap();
         let result = from_json(path);

--- a/src/output/export/mod.rs
+++ b/src/output/export/mod.rs
@@ -74,7 +74,7 @@ pub use json::{JsonError, from_json, to_json};
 ///
 /// # Implementing this trait
 ///
-/// A new format must implement [`export_single`] and [`export_multi`].
+/// A new format must implement `export_single` and `export_multi`.
 /// Formats that do not distinguish between the two cases can delegate one to the other.
 pub trait Exporter {
     /// Error type specific to this export format.

--- a/src/output/visualization/mod.rs
+++ b/src/output/visualization/mod.rs
@@ -52,6 +52,7 @@
 
 pub mod chromatogram;
 pub mod config;
+/// Spatial concentration profile plots (steady-state and evolution over time).
 pub mod steady;
 
 pub use config::PlotConfig;

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -93,7 +93,9 @@
 //! - **Langmuir 1D**: 1D chromatography with modified Langmuir isotherm
 
 // module declaration
+/// Core data types: [`PhysicalData`], [`PhysicalState`], and [`PhysicalQuantity`].
 pub mod data;
+/// Core traits: [`PhysicalModel`] and [`Exportable`].
 pub mod traits;
 // Model implementation
 

--- a/src/physics/traits.rs
+++ b/src/physics/traits.rs
@@ -701,6 +701,45 @@ pub trait PhysicalModel: Send + Sync {
     fn description(&self) -> Option<&str> {
         None
     }
+
+    /// Sets the injection profile for a species or for all species at once.
+    ///
+    /// This is the single injection entry-point on the trait. The caller
+    /// (config loader, DD-015) never needs to know the concrete model type.
+    ///
+    /// - `species = None`  → applies to all species (or the sole species for
+    ///   single-species models).
+    /// - `species = Some(name)` → targets one named species; models that do
+    ///   not support named species may treat this as a no-op or return `Err`.
+    ///
+    /// The default implementation is a no-op (`Ok(())`). Models that use
+    /// temporal injection override this method and dispatch internally.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if `species` names a species that does not exist in the
+    /// model.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use chrom_rs::physics::PhysicalModel;
+    /// use chrom_rs::models::TemporalInjection;
+    /// use std::collections::HashMap;
+    ///
+    /// fn apply(model: &mut dyn PhysicalModel) {
+    ///     let mut map = HashMap::new();
+    ///     map.insert(None, TemporalInjection::dirac(5.0, 0.1));
+    ///     map.insert(Some("B".to_string()), TemporalInjection::none());
+    ///     model.set_injections(&map).unwrap();
+    /// }
+    /// ```
+    fn set_injections(
+        &mut self,
+        _injections: &HashMap<Option<String>, crate::models::TemporalInjection>,
+    ) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 // =============================================================================
@@ -872,7 +911,7 @@ pub trait Exportable {
 /// Extracts outlet data for any physical quantity from a trajectory state at index `idx`.
 ///
 /// The "outlet" is the last spatial point (column exit), consistent with
-/// the upwind spatial discretisation used by all Langmuir models.
+/// the upwind spatial discretization used by all Langmuir models.
 ///
 /// This function is generic over [`PhysicalQuantity`]: pass
 /// `PhysicalQuantity::Concentration` for concentration profiles,
@@ -936,7 +975,7 @@ pub fn outlet_data(
 ///
 /// Guarantees the trailing edge of a chromatographic peak is never truncated.
 ///
-/// | `n` | Behaviour |
+/// | `n` | Behavior |
 /// |---|---|
 /// | `None` | All indices `0..total` |
 /// | `Some(0)` or `Some(n ≥ total)` | All indices |
@@ -1378,7 +1417,7 @@ mod tests {
     fn test_outlet_data_scalar() {
         let state = PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Scalar(3.14));
         assert_eq!(
-            super::outlet_data(PhysicalQuantity::Concentration, &[state], 0),
+            outlet_data(PhysicalQuantity::Concentration, &[state], 0),
             vec![3.14]
         );
     }
@@ -1389,53 +1428,53 @@ mod tests {
             PhysicalQuantity::Concentration,
             PhysicalData::Vector(nalgebra::DVector::from_vec(vec![0.0, 0.5, 1.0])),
         );
-        let outlet = super::outlet_data(PhysicalQuantity::Concentration, &[state], 0);
+        let outlet = outlet_data(PhysicalQuantity::Concentration, &[state], 0);
         assert!((outlet[0] - 1.0).abs() < 1e-12);
     }
 
     #[test]
     fn test_outlet_data_out_of_bounds() {
         let state = PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Scalar(1.0));
-        assert!(super::outlet_data(PhysicalQuantity::Concentration, &[state], 99).is_empty());
+        assert!(outlet_data(PhysicalQuantity::Concentration, &[state], 99).is_empty());
     }
 
     #[test]
     fn test_outlet_data_unknown_quantity() {
         let state = PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Scalar(1.0));
         // Temperature not present → empty Vec
-        assert!(super::outlet_data(PhysicalQuantity::Temperature, &[state], 0).is_empty());
+        assert!(outlet_data(PhysicalQuantity::Temperature, &[state], 0).is_empty());
     }
 
     #[test]
     fn test_sample_indices_full() {
-        assert_eq!(super::sample_indices(4, None), vec![0, 1, 2, 3]);
+        assert_eq!(sample_indices(4, None), vec![0, 1, 2, 3]);
     }
 
     #[test]
     fn test_sample_indices_five_from_hundred() {
         // Formula: (i * 99) / 4 with integer division → [0, 24, 49, 74, 99]
-        assert_eq!(super::sample_indices(100, Some(5)), vec![0, 24, 49, 74, 99]);
+        assert_eq!(sample_indices(100, Some(5)), vec![0, 24, 49, 74, 99]);
     }
 
     #[test]
     fn test_sample_indices_single() {
-        assert_eq!(super::sample_indices(100, Some(1)), vec![0]);
+        assert_eq!(sample_indices(100, Some(1)), vec![0]);
     }
 
     #[test]
     fn test_sample_indices_larger_than_total() {
-        assert_eq!(super::sample_indices(3, Some(10)), vec![0, 1, 2]);
+        assert_eq!(sample_indices(3, Some(10)), vec![0, 1, 2]);
     }
 
     #[test]
     fn test_export_error_display_missing_key() {
-        let e = super::ExportError::MissingKey("metadata".into());
+        let e = ExportError::MissingKey("metadata".into());
         assert_eq!(e.to_string(), "export map: missing key 'metadata'");
     }
 
     #[test]
     fn test_export_error_display_mismatch() {
-        let e = super::ExportError::SpeciesCountMismatch {
+        let e = ExportError::SpeciesCountMismatch {
             expected: 2,
             got: 1,
         };

--- a/src/physics/traits.rs
+++ b/src/physics/traits.rs
@@ -705,7 +705,7 @@ pub trait PhysicalModel: Send + Sync {
     /// Sets the injection profile for a species or for all species at once.
     ///
     /// This is the single injection entry-point on the trait. The caller
-    /// (config loader, DD-015) never needs to know the concrete model type.
+    /// (config loader) never needs to know the concrete model type.
     ///
     /// - `species = None`  → applies to all species (or the sole species for
     ///   single-species models).
@@ -818,7 +818,7 @@ impl std::error::Error for ExportError {}
 /// [`from_map`](Exportable::from_map) is **not object-safe** (`Self: Sized`).
 /// It is intended for concrete types only, typically in the CLI layer.
 ///
-/// # JSON layout convention (DD-010)
+/// # JSON layout convention
 ///
 /// ```json
 /// {

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -353,7 +353,9 @@
 // =================================================================================================
 // Module Declarations
 // =================================================================================================
+
 mod boundary;
+/// Concrete solver implementations: Forward Euler and Runge-Kutta 4.
 pub mod methods;
 mod scenario;
 mod traits;

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -223,6 +223,7 @@ mod tests {
     }
 
     /// advanced custom scenario
+    #[allow(dead_code)]
     fn create_custom_scenario(
         name: &str,
         dimensions: Vec<DimensionBoundary>,

--- a/src/solver/traits.rs
+++ b/src/solver/traits.rs
@@ -260,7 +260,7 @@ pub struct SolverConfiguration {
     /// Type of solver and its parameters
     pub solver_type: SolverType,
 
-    /// Trajectory sampling interval for JSON export (DD-010 / DD-015).
+    /// Trajectory sampling interval for JSON export.
     ///
     /// - `None` — full trajectory is retained (default).
     /// - `Some(n)` — only every `n`-th state is kept; the final state is
@@ -306,7 +306,7 @@ impl SolverConfiguration {
     /// Enables trajectory subsampling — keeps every `n`-th state.
     ///
     /// The final state is always present in the output regardless of `n`.
-    /// Used by the CLI layer when `step` is set in `solver.yml` (DD-015).
+    /// Used by the CLI layer when `step` is set in `solver.yml`.
     ///
     /// # Example
     /// ```rust

--- a/src/solver/traits.rs
+++ b/src/solver/traits.rs
@@ -257,12 +257,32 @@ impl SolverType {
 /// ```
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SolverConfiguration {
-    /// Type of solver and its paraméters
+    /// Type of solver and its parameters
     pub solver_type: SolverType,
+
+    /// Trajectory sampling interval for JSON export (DD-010 / DD-015).
+    ///
+    /// - `None` — full trajectory is retained (default).
+    /// - `Some(n)` — only every `n`-th state is kept; the final state is
+    ///   always included regardless of the value.
+    ///
+    /// Passed to [`sample_indices`](crate::physics::sample_indices) in the
+    /// CLI layer. Has no effect on the numerical integration itself.
+    ///
+    /// # YAML / JSON
+    ///
+    /// ```yaml
+    /// step: null   # full trajectory
+    /// step: 10     # every 10th step
+    /// ```
+    #[serde(default)]
+    pub step: Option<usize>,
 }
 
 impl SolverConfiguration {
     /// Create a new configuration with a given solver type
+    ///
+    /// `step` defaults to `None` — full trajectory retained.
     ///
     /// # Example
     /// ```rust
@@ -274,9 +294,31 @@ impl SolverConfiguration {
     ///         time_steps: 1000,
     ///     }
     /// );
+    /// assert!(config.step.is_none());
     /// ```
     pub fn new(solver_type: SolverType) -> Self {
-        Self { solver_type }
+        Self {
+            solver_type,
+            step: None,
+        }
+    }
+
+    /// Enables trajectory subsampling — keeps every `n`-th state.
+    ///
+    /// The final state is always present in the output regardless of `n`.
+    /// Used by the CLI layer when `step` is set in `solver.yml` (DD-015).
+    ///
+    /// # Example
+    /// ```rust
+    /// use chrom_rs::solver::SolverConfiguration;
+    ///
+    /// let config = SolverConfiguration::time_evolution(600.0, 10000)
+    ///     .with_step(50);
+    /// assert_eq!(config.step, Some(50));
+    /// ```
+    pub fn with_step(mut self, n: usize) -> Self {
+        self.step = Some(n);
+        self
     }
 
     /// Create a time evolution configuration
@@ -606,6 +648,7 @@ pub trait Solver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json;
 
     // ==================== SolverType Tests ====================
 
@@ -695,6 +738,89 @@ mod tests {
 
         let invalid = SolverConfiguration::time_evolution(-1.0, 1000);
         assert!(invalid.validate().is_err());
+    }
+
+    // ── step field ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_step_defaults_to_none_on_all_factories() {
+        // Every constructor path must leave step = None unless explicitly set.
+        assert!(
+            SolverConfiguration::time_evolution(10.0, 1000)
+                .step
+                .is_none()
+        );
+        assert!(SolverConfiguration::iterative(1e-6, 100).step.is_none());
+        assert!(SolverConfiguration::analytical(5.0).step.is_none());
+        assert!(
+            SolverConfiguration::spatial_discretization(100, 1000)
+                .step
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_with_step_sets_value() {
+        let config = SolverConfiguration::time_evolution(600.0, 10000).with_step(50);
+        assert_eq!(config.step, Some(50));
+    }
+
+    #[test]
+    fn test_with_step_preserves_solver_type() {
+        let config = SolverConfiguration::time_evolution(600.0, 10000).with_step(50);
+        assert!(matches!(
+            config.solver_type,
+            SolverType::TimeEvolution { .. }
+        ));
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_with_step_zero_accepted() {
+        // step=0 is treated as "full trajectory" by sample_indices — not an error.
+        let config = SolverConfiguration::time_evolution(10.0, 1000).with_step(0);
+        assert_eq!(config.step, Some(0));
+    }
+
+    #[test]
+    fn test_step_serde_default_when_field_absent() {
+        // A JSON payload without the "step" key must deserialize to step = None.
+        let json = r#"{"solver_type":{"TimeEvolution":{"total_time":10.0,"time_steps":1000}}}"#;
+        let config: SolverConfiguration =
+            serde_json::from_str(json).expect("deserialisation must succeed when step is absent");
+        assert!(config.step.is_none(), "step must default to None");
+    }
+
+    #[test]
+    fn test_step_serde_null() {
+        // Explicit null (YAML: `step: null`) must also deserialize to None.
+        let json = r#"{"solver_type":{"TimeEvolution":{"total_time":10.0,"time_steps":1000}},"step":null}"#;
+        let config: SolverConfiguration =
+            serde_json::from_str(json).expect("deserialisation must succeed for step: null");
+        assert!(config.step.is_none(), "step: null must yield None");
+    }
+
+    #[test]
+    fn test_step_serde_with_value() {
+        // A concrete value must round-trip correctly.
+        let json =
+            r#"{"solver_type":{"TimeEvolution":{"total_time":10.0,"time_steps":1000}},"step":10}"#;
+        let config: SolverConfiguration =
+            serde_json::from_str(json).expect("deserialisation must succeed for step: 10");
+        assert_eq!(config.step, Some(10));
+    }
+
+    #[test]
+    fn test_step_serde_round_trip() {
+        let original = SolverConfiguration::time_evolution(600.0, 10000).with_step(25);
+        let serialised = serde_json::to_string(&original).expect("serialisation must succeed");
+        let restored: SolverConfiguration =
+            serde_json::from_str(&serialised).expect("deserialisation must succeed");
+        assert_eq!(restored.step, Some(25));
+        assert!(matches!(
+            restored.solver_type,
+            SolverType::TimeEvolution { .. }
+        ));
     }
 
     // ==================== SimulationResult Tests ====================

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,288 @@
+//! Integration tests for the `cli/` module.
+//!
+//! These tests exercise [`RunHandler::execute`] end-to-end with real
+//! configuration files, covering the paths not reachable from unit tests:
+//!
+//! - `read_model_file` / `peek_root_key` / `deserialise_inner`
+//! - `resolve_species_names` / `resolve_export_map`
+//! - `RunHandler::execute` — single-species and multi-species dispatch
+//! - CSV, plot, and JSON output paths
+//!
+//! Each test creates a temporary project directory populated with copies of
+//! the config files from `examples/config/`.  All outputs land in that
+//! directory and are cleaned up automatically by `tempfile::TempDir`.
+//!
+//! `--project-dir` is passed explicitly in the args map so that
+//! `RunHandler::execute` resolves all file paths against the temp directory
+//! rather than the current working directory.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use chrom_rs::cli::app::{ChromContext, RunHandler};
+use dynamic_cli::{CommandHandler, ExecutionContext};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Copies every listed source file into `dest_dir` under its basename.
+fn copy_files(files: &[&str], dest_dir: &Path) {
+    for src in files {
+        let name = Path::new(src).file_name().expect("file must have a name");
+        std::fs::copy(src, dest_dir.join(name))
+            .unwrap_or_else(|e| panic!("cannot copy {src}: {e}"));
+    }
+}
+
+/// Builds the `args` map passed to `RunHandler::execute`.
+fn make_args(entries: &[(&str, &str)]) -> HashMap<String, String> {
+    entries
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+/// Runs the handler with `project-dir` pointing at `dir`.
+///
+/// `RunHandler::execute` reads `project-dir` from `args` and calls
+/// `set_project_dir` internally — the context starts with the default `.`.
+fn run(dir: &Path, args: &HashMap<String, String>) {
+    let mut ctx = ChromContext::new();
+    RunHandler
+        .execute(&mut ctx as &mut dyn ExecutionContext, args)
+        .unwrap_or_else(|e| panic!("RunHandler::execute failed: {e}"));
+    // suppress unused warning
+    let _ = dir;
+}
+
+// ── Single-species (LangmuirSingle / TFA) ────────────────────────────────────
+
+/// Gaussian injection + RK4 → single-species dispatch, CSV output.
+#[test]
+fn test_run_tfa_gaussian_rk4_csv() {
+    let dir = tempfile::tempdir().unwrap();
+    copy_files(
+        &[
+            "examples/config/tfa/model.yml",
+            "examples/config/tfa/scenario_gaussian.yml",
+            "examples/config/tfa/solver_rk4.yml",
+        ],
+        dir.path(),
+    );
+
+    let project_dir = dir.path().to_str().unwrap();
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        ("model", "model.yml"),
+        ("scenario", "scenario_gaussian.yml"),
+        ("solver", "solver_rk4.yml"),
+        ("output-csv", "result.csv"),
+    ]);
+
+    run(dir.path(), &args);
+    assert!(
+        dir.path().join("result.csv").exists(),
+        "CSV must be created"
+    );
+}
+
+/// Gaussian injection + Euler → single-species dispatch, JSON export.
+#[test]
+fn test_run_tfa_gaussian_euler_json() {
+    let dir = tempfile::tempdir().unwrap();
+    copy_files(
+        &[
+            "examples/config/tfa/model.yml",
+            "examples/config/tfa/scenario_gaussian.yml",
+            "examples/config/tfa/solver_euler.yml",
+        ],
+        dir.path(),
+    );
+
+    let project_dir = dir.path().to_str().unwrap();
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        ("model", "model.yml"),
+        ("scenario", "scenario_gaussian.yml"),
+        ("solver", "solver_euler.yml"),
+        ("export-json", "result.json"),
+    ]);
+
+    run(dir.path(), &args);
+    assert!(
+        dir.path().join("result.json").exists(),
+        "JSON must be created"
+    );
+}
+
+/// Gaussian injection + RK4 → plot output.
+#[test]
+fn test_run_tfa_gaussian_rk4_plot() {
+    let dir = tempfile::tempdir().unwrap();
+    copy_files(
+        &[
+            "examples/config/tfa/model.yml",
+            "examples/config/tfa/scenario_gaussian.yml",
+            "examples/config/tfa/solver_rk4.yml",
+        ],
+        dir.path(),
+    );
+
+    let project_dir = dir.path().to_str().unwrap();
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        ("model", "model.yml"),
+        ("scenario", "scenario_gaussian.yml"),
+        ("solver", "solver_rk4.yml"),
+        ("output-plot", "result.png"),
+    ]);
+
+    run(dir.path(), &args);
+    assert!(
+        dir.path().join("result.png").exists(),
+        "plot must be created"
+    );
+}
+
+/// All three outputs at once — full single-species output chain.
+#[test]
+fn test_run_tfa_all_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    copy_files(
+        &[
+            "examples/config/tfa/model.yml",
+            "examples/config/tfa/scenario_gaussian.yml",
+            "examples/config/tfa/solver_rk4.yml",
+        ],
+        dir.path(),
+    );
+
+    let project_dir = dir.path().to_str().unwrap();
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        ("model", "model.yml"),
+        ("scenario", "scenario_gaussian.yml"),
+        ("solver", "solver_rk4.yml"),
+        ("output-csv", "result.csv"),
+        ("output-plot", "result.png"),
+        ("export-json", "result.json"),
+    ]);
+
+    run(dir.path(), &args);
+    assert!(
+        dir.path().join("result.csv").exists(),
+        "CSV must be created"
+    );
+    assert!(
+        dir.path().join("result.png").exists(),
+        "plot must be created"
+    );
+    assert!(
+        dir.path().join("result.json").exists(),
+        "JSON must be created"
+    );
+}
+
+// ── Multi-species (LangmuirMulti / Acids competitive) ────────────────────────
+
+/// Acids competitive + RK4 → multi-species dispatch, CSV output.
+#[test]
+fn test_run_acids_multi_rk4_csv() {
+    let dir = tempfile::tempdir().unwrap();
+    copy_files(
+        &[
+            "examples/config/acids/model.yml",
+            "examples/config/acids/scenario_gaussian.yml",
+            "examples/config/acids/solver_rk4.yml",
+        ],
+        dir.path(),
+    );
+
+    let project_dir = dir.path().to_str().unwrap();
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        ("model", "model.yml"),
+        ("scenario", "scenario_gaussian.yml"),
+        ("solver", "solver_rk4.yml"),
+        ("output-csv", "result.csv"),
+    ]);
+
+    run(dir.path(), &args);
+    assert!(
+        dir.path().join("result.csv").exists(),
+        "multi-species CSV must be created"
+    );
+}
+
+/// Acids competitive + Euler → multi-species dispatch, all outputs.
+#[test]
+fn test_run_acids_multi_euler_all_outputs() {
+    let dir = tempfile::tempdir().unwrap();
+    copy_files(
+        &[
+            "examples/config/acids/model.yml",
+            "examples/config/acids/scenario_gaussian.yml",
+            "examples/config/acids/solver_euler.yml",
+        ],
+        dir.path(),
+    );
+
+    let project_dir = dir.path().to_str().unwrap();
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        ("model", "model.yml"),
+        ("scenario", "scenario_gaussian.yml"),
+        ("solver", "solver_euler.yml"),
+        ("output-csv", "result.csv"),
+        ("output-plot", "result.png"),
+        ("export-json", "result.json"),
+    ]);
+
+    run(dir.path(), &args);
+    assert!(
+        dir.path().join("result.csv").exists(),
+        "multi-species CSV must be created"
+    );
+    assert!(
+        dir.path().join("result.png").exists(),
+        "multi-species plot must be created"
+    );
+    assert!(
+        dir.path().join("result.json").exists(),
+        "multi-species JSON must be created"
+    );
+}
+
+// ── Error paths ───────────────────────────────────────────────────────────────
+
+/// Missing required option returns an error.
+#[test]
+fn test_run_missing_model_arg_fails() {
+    let dir = tempfile::tempdir().unwrap();
+    let project_dir = dir.path().to_str().unwrap();
+
+    let args = make_args(&[
+        ("project-dir", project_dir),
+        // "model" intentionally absent
+        ("scenario", "scenario.yml"),
+        ("solver", "solver.yml"),
+    ]);
+
+    let mut ctx = ChromContext::new();
+    let result = RunHandler.execute(&mut ctx as &mut dyn ExecutionContext, &args);
+    assert!(result.is_err(), "missing --model must return an error");
+}
+
+/// Path traversal in project-dir is rejected.
+#[test]
+fn test_run_project_dir_traversal_fails() {
+    let args = make_args(&[
+        ("project-dir", "../etc"),
+        ("model", "model.yml"),
+        ("scenario", "scenario.yml"),
+        ("solver", "solver.yml"),
+    ]);
+
+    let mut ctx = ChromContext::new();
+    let result = RunHandler.execute(&mut ctx as &mut dyn ExecutionContext, &args);
+    assert!(result.is_err(), "path traversal must return an error");
+}

--- a/tests/common/mock_models.rs
+++ b/tests/common/mock_models.rs
@@ -129,6 +129,7 @@ pub struct LinearTransport {
     pub velocity: f64,
 }
 
+#[allow(dead_code)]
 impl LinearTransport {
     pub fn new(points: usize, velocity: f64) -> Self {
         Self { points, velocity }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,9 @@ pub mod mock_models;
 pub mod test_helpers;
 
 // Re-export commonly used items
+#[allow(unused_imports)]
 pub use mock_models::{ConstantGrowth, ExponentialDecay, LinearTransport};
+#[allow(unused_imports)]
 pub use test_helpers::{
     assert_states_close, compute_l2_error, create_simple_scenario, relative_error,
 };

--- a/tests/common/test_helpers.rs
+++ b/tests/common/test_helpers.rs
@@ -5,6 +5,7 @@ use chrom_rs::physics::{PhysicalQuantity, PhysicalState};
 use chrom_rs::solver::{DomainBoundaries, Scenario};
 
 /// Assert that two physical states are close (within tolerance)
+#[allow(dead_code)]
 pub fn assert_states_close(
     state1: &PhysicalState,
     state2: &PhysicalState,
@@ -38,6 +39,7 @@ pub fn assert_states_close(
 }
 
 /// Compute L2 norm error between two states
+#[allow(dead_code)]
 pub fn compute_l2_error(state1: &PhysicalState, state2: &PhysicalState) -> f64 {
     let mut sum_squared_diff = 0.0;
     let mut count = 0;
@@ -65,6 +67,7 @@ pub fn compute_l2_error(state1: &PhysicalState, state2: &PhysicalState) -> f64 {
 }
 
 /// Create a simple scenario for testing
+#[allow(dead_code)]
 pub fn create_simple_scenario(model: Box<dyn PhysicalModel>) -> Scenario {
     let initial = model.setup_initial_state();
     let boundaries = DomainBoundaries::temporal(initial);
@@ -83,6 +86,7 @@ pub fn relative_error(actual: f64, expected: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[allow(unused)]
     use chrom_rs::physics::PhysicalData;
 
     #[test]


### PR DESCRIPTION
## v0.2.0 · Application Layer

### Summary

This PR completes the Application Layer milestone, implementing the user-facing CLI pipeline and all supporting infrastructure required for the first crates.io publication.

---

### What's included

**CLI module (`src/cli/`)**
- `ChromContext` — execution context with validated `--project-dir` (no `..` traversal, existence and read/write checks)
- `RunHandler` — full simulation pipeline: load model → apply scenario → configure solver → solve → CSV/plot/JSON outputs
- `build_app()` — assembles the `dynamic-cli` application from the embedded `commands.yml`
- Command surface: `chrom-rs run --model --scenario --solver [--project-dir] [--output-csv] [--output-plot] [--export-json]`

**Configuration loaders (`src/config/`)**
- Three independent file loaders: `load_model`, `load_scenario`, `load_solver`
- YAML and JSON supported; format inferred from extension
- `load_scenario` applies injections to the model in-place before returning `DomainBoundaries`

**Config-file examples (`examples/`)**
- `tfa_from_config.rs` — reproduces `tfa.rs` via config files; results numerically identical
- `acids_from_config.rs` — reproduces `acids_multi.rs`; solo phase derives `LangmuirSingle` from `LangmuirMulti` parameters
- `examples/config/tfa/` and `examples/config/acids/` — shared YAML fixtures

**Integration tests (`tests/cli_integration.rs`)**
- 8 end-to-end tests via `RunHandler::execute` using the `examples/config/` fixtures
- Covers single-species (TFA) and multi-species (acids competitive) dispatch
- Covers CSV, plot, and JSON output paths; error paths (missing arg, path traversal)

**Documentation**
- All public items documented; zero `cargo doc --no-deps` warnings
- Broken intra-doc links fixed across `cli/`, `config/`, `models/`, `output/`, `solver/`
- Private items (`ContextError`, `TemporalInjectionSnapshot`, `resolve_*`) referenced as plain text

**Bug fix**
- `plot_chromatogram` / `plot_chromatogram_multi`: use `model.points()` (spatial points) instead of `result.time_points.len()` — prevents matrix index out of bounds

---

### Issues closed

Closes #32 — Implement `cli/` module
Closes #33 — JSON and YAML configuration loading
Closes #34 — JSON export of `SimulationResult`
Closes #35 — Coverage audit `cli/` ≥ 80%
Closes #36 — Rustdoc `cli/` and `output/`
Closes #46 — DD-015 configuration file layout

---

### Metrics

| Module | Line coverage |
|---|---|
| `cli/app.rs` | 92.1% |
| `cli/mod.rs` | 90.0% |
| All other modules | ≥ 80% (no regression) |

`cargo clippy -- -D warnings` : ✅ zero errors  
`cargo doc --no-deps` : ✅ zero warnings  
`cargo test` : ✅ zero warnings, zero failures