### PR TITLE
feat: v0.3.0 · Domain & Context — domain/ module and ComputeContext

### DIFF
--- a/benches/langmuir_performance.rs
+++ b/benches/langmuir_performance.rs
@@ -1428,7 +1428,7 @@ mod tests {
     fn test_tfa_single_builds_correctly() {
         let model = tfa_single(100);
         assert_eq!(model.spatial_points(), 100);
-        assert!((model.length() - COLUMN_LENGTH).abs() < 1e-12);
+        assert!((model.column_length() - COLUMN_LENGTH).abs() < 1e-12);
     }
 
     #[test]

--- a/benches/solver_performance.rs
+++ b/benches/solver_performance.rs
@@ -103,7 +103,11 @@ impl PhysicalModel for SimpleModel {
         self.points
     }
 
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        _ctx: &chrom_rs::physics::ComputeContext,
+    ) -> PhysicalState {
         let mut result = state.clone();
         if let Some(conc) = result.get_mut(PhysicalQuantity::Concentration) {
             conc.apply(|x| -0.1 * x);

--- a/examples/config/tfa/model.yml
+++ b/examples/config/tfa/model.yml
@@ -2,8 +2,8 @@ LangmuirSingle:
   lambda: 1.2
   langmuir_k: 0.4
   port_number: 2.0
-  length: 0.25
-  nz: 100
+  column_length: 0.25
+  n_points: 100
   dz: 0.0025
   fe: 1.5
   ue: 0.0025

--- a/examples/diffusion.rs
+++ b/examples/diffusion.rs
@@ -55,7 +55,11 @@ impl PhysicalModel for FisherKPP {
         self.n_points
     }
 
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        _ctx: &chrom_rs::physics::ComputeContext,
+    ) -> PhysicalState {
         let u = state
             .get(PhysicalQuantity::Concentration)
             .expect("Concentration not found")

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -537,8 +537,8 @@ LangmuirSingle:
   lambda: 1.2
   langmuir_k: 0.4
   port_number: 2.0
-  length: 0.25
-  nz: 100
+  column_length: 0.25
+  n_points: 100
   dz: 0.0025
   fe: 1.5
   ue: 0.0025

--- a/src/config/model.rs
+++ b/src/config/model.rs
@@ -113,8 +113,8 @@ LangmuirSingle:
   lambda: 1.2
   langmuir_k: 0.4
   port_number: 2.0
-  length: 0.25
-  nz: 100
+  column_length: 0.25
+  n_points: 100
   dz: 0.0025
   fe: 1.5
   ue: 0.0025
@@ -179,8 +179,8 @@ LangmuirMulti:
     "lambda": 1.2,
     "langmuir_k": 0.4,
     "port_number": 2.0,
-    "length": 0.25,
-    "nz": 100,
+    "column_length": 0.25,
+    "n_points": 100,
     "dz": 0.0025,
     "fe": 1.5,
     "ue": 0.0025,

--- a/src/domain/column.rs
+++ b/src/domain/column.rs
@@ -1,0 +1,330 @@
+//! Colonne chromatographique — physical geometry of the chromatographic column.
+//!
+//! Ce module définit [`Column`], le type canonique décrivant la géométrie
+//! physique d'une colonne chromatographique. Il est indépendant de tout
+//! modèle mathématique et sert de couche de construction validée pour
+//! [`LangmuirSingle`](crate::models::LangmuirSingle) et
+//! [`LangmuirMulti`](crate::models::LangmuirMulti), ainsi que pour tout
+//! futur modèle de transport.
+//!
+//! # Physical background
+//!
+//! A chromatographic column is characterised by:
+//!
+//! - Its **length** $L$ \[m\] — the axial dimension over which separation occurs.
+//! - Its **extragranular porosity** $\varepsilon_e \in (0, 1)$ — the void fraction
+//!   available to the mobile phase between the stationary-phase particles.
+//! - The **number of spatial nodes** $N_z \geq 2$ — the discretisation of the
+//!   axial coordinate used by the numerical solver.
+//! - Optionally, its **inner diameter** $d$ \[m\] — required only when converting
+//!   between volumetric flow rate $F$ \[m³/s\] and superficial velocity $u$ \[m/s\].
+//!
+//! # Derived quantities
+//!
+//! | Symbol | Formula | Meaning |
+//! |--------|---------|---------|
+//! | $\Delta z$ | $L / N_z$ | Spatial cell width |
+//! | $F_e$ | $(1 - \varepsilon_e) / \varepsilon_e$ | Phase ratio |
+//!
+//! # Example
+//!
+//! ```rust
+//! use chrom_rs::domain::Column;
+//!
+//! let col = Column::new(0.25, 100, 0.4, None).unwrap();
+//!
+//! assert!((col.dz() - 0.0025).abs() < 1e-12);
+//! assert!((col.phase_ratio() - 1.5).abs() < 1e-12);
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// =============================================================================
+// ColumnError
+// =============================================================================
+
+/// Erreurs de construction d'une [`Column`] — Column construction errors.
+#[derive(Debug)]
+pub enum ColumnError {
+    /// La longueur doit être strictement positive — column length must be > 0.
+    InvalidLength(f64),
+
+    /// Le nombre de points doit être ≥ 2 — spatial points must be ≥ 2.
+    InvalidPoints(usize),
+
+    /// La porosité doit appartenir à (0, 1) — porosity must be in (0, 1).
+    InvalidPorosity(f64),
+
+    /// Le diamètre, s'il est fourni, doit être strictement positif.
+    /// Diameter, when provided, must be > 0.
+    InvalidDiameter(f64),
+}
+
+impl fmt::Display for ColumnError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ColumnError::InvalidLength(v) => {
+                write!(f, "column: length must be > 0, got {v}")
+            }
+            ColumnError::InvalidPoints(n) => {
+                write!(f, "column: n_points must be ≥ 2, got {n}")
+            }
+            ColumnError::InvalidPorosity(v) => {
+                write!(f, "column: porosity must be in (0, 1), got {v}")
+            }
+            ColumnError::InvalidDiameter(v) => {
+                write!(f, "column: diameter must be > 0, got {v}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ColumnError {}
+
+// =============================================================================
+// Column
+// =============================================================================
+
+/// Géométrie physique d'une colonne chromatographique.
+///
+/// `Column` encapsule les paramètres géométriques et de discrétisation d'une
+/// colonne. Il sert de façade de construction validée : les modèles physiques
+/// (`LangmuirSingle`, `LangmuirMulti`, …) acceptent une `&Column` dans leur
+/// constructeur `from_domain` et en extraient les champs nécessaires.
+///
+/// # Fields
+///
+/// | Field | Symbol | Unit | Constraint |
+/// |-------|--------|------|-----------|
+/// | `column_length` | $L$ | m | $> 0$ |
+/// | `n_points` | $N_z$ | — | $\geq 2$ |
+/// | `porosity` | $\varepsilon_e$ | — | $(0, 1)$ |
+/// | `diameter` | $d$ | m | $> 0$ if `Some` |
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::domain::Column;
+///
+/// let col = Column::new(0.25, 100, 0.4, None).unwrap();
+/// assert_eq!(col.n_points, 100);
+/// assert!((col.phase_ratio() - 1.5).abs() < 1e-12);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Column {
+    /// Longueur de la colonne $L$ \[m\] — column length.
+    pub column_length: f64,
+
+    /// Nombre de nœuds spatiaux $N_z$ — number of spatial discretisation nodes.
+    pub n_points: usize,
+
+    /// Porosité extragranulaire $\varepsilon_e \in (0, 1)$ — extragranular porosity.
+    pub porosity: f64,
+
+    /// Diamètre interne $d$ \[m\] — inner diameter (optional).
+    ///
+    /// Requis uniquement pour convertir un débit volumique $F$ en vitesse
+    /// superficielle $u$. Required only to convert volumetric flow rate to
+    /// superficial velocity.
+    pub diameter: Option<f64>,
+}
+
+impl Column {
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
+    /// Construit une colonne après validation des paramètres.
+    ///
+    /// Creates a validated column.
+    ///
+    /// # Arguments
+    ///
+    /// * `column_length` — $L$ \[m\], must be > 0
+    /// * `n_points`      — $N_z$, must be ≥ 2
+    /// * `porosity`      — $\varepsilon_e$, must be in (0, 1)
+    /// * `diameter`      — $d$ \[m\], must be > 0 when `Some`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ColumnError`] if any constraint is violated.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Column, ColumnError};
+    ///
+    /// assert!(Column::new(0.25, 100, 0.4, None).is_ok());
+    /// assert!(matches!(Column::new(-1.0, 100, 0.4, None), Err(ColumnError::InvalidLength(_))));
+    /// assert!(matches!(Column::new(0.25, 1, 0.4, None),   Err(ColumnError::InvalidPoints(_))));
+    /// assert!(matches!(Column::new(0.25, 100, 1.5, None), Err(ColumnError::InvalidPorosity(_))));
+    /// assert!(matches!(Column::new(0.25, 100, 0.4, Some(-0.01)), Err(ColumnError::InvalidDiameter(_))));
+    /// ```
+    pub fn new(
+        column_length: f64,
+        n_points: usize,
+        porosity: f64,
+        diameter: Option<f64>,
+    ) -> Result<Self, ColumnError> {
+        if column_length <= 0.0 {
+            return Err(ColumnError::InvalidLength(column_length));
+        }
+        if n_points < 2 {
+            return Err(ColumnError::InvalidPoints(n_points));
+        }
+        if porosity <= 0.0 || porosity >= 1.0 {
+            return Err(ColumnError::InvalidPorosity(porosity));
+        }
+        if let Some(d) = diameter
+            && d <= 0.0
+        {
+            return Err(ColumnError::InvalidDiameter(d));
+        }
+        Ok(Self {
+            column_length,
+            n_points,
+            porosity,
+            diameter,
+        })
+    }
+
+    // =========================================================================
+    // Derived accessors
+    // =========================================================================
+
+    /// Largeur d'une cellule spatiale $\Delta z = L / N_z$ \[m\].
+    ///
+    /// Spatial cell width.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::Column;
+    ///
+    /// let col = Column::new(0.25, 100, 0.4, None).unwrap();
+    /// assert!((col.dz() - 0.0025).abs() < 1e-12);
+    /// ```
+    #[inline]
+    pub fn dz(&self) -> f64 {
+        self.column_length / self.n_points as f64
+    }
+
+    /// Rapport de phase $F_e = (1 - \varepsilon_e) / \varepsilon_e$.
+    ///
+    /// Phase ratio — ratio of stationary-phase volume to mobile-phase volume.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::Column;
+    ///
+    /// let col = Column::new(0.25, 100, 0.4, None).unwrap();
+    /// // Fe = (1 - 0.4) / 0.4 = 1.5
+    /// assert!((col.phase_ratio() - 1.5).abs() < 1e-12);
+    /// ```
+    #[inline]
+    pub fn phase_ratio(&self) -> f64 {
+        (1.0 - self.porosity) / self.porosity
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_column_valid() {
+        let col = Column::new(0.25, 100, 0.4, None).unwrap();
+        assert_eq!(col.column_length, 0.25);
+        assert_eq!(col.n_points, 100);
+        assert!((col.porosity - 0.4).abs() < 1e-12);
+        assert!(col.diameter.is_none());
+    }
+
+    #[test]
+    fn test_column_with_diameter() {
+        let col = Column::new(0.25, 100, 0.4, Some(0.01)).unwrap();
+        assert!((col.diameter.unwrap() - 0.01).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_column_invalid_length() {
+        assert!(matches!(
+            Column::new(0.0, 100, 0.4, None),
+            Err(ColumnError::InvalidLength(_))
+        ));
+        assert!(matches!(
+            Column::new(-1.0, 100, 0.4, None),
+            Err(ColumnError::InvalidLength(_))
+        ));
+    }
+
+    #[test]
+    fn test_column_invalid_points() {
+        assert!(matches!(
+            Column::new(0.25, 0, 0.4, None),
+            Err(ColumnError::InvalidPoints(_))
+        ));
+        assert!(matches!(
+            Column::new(0.25, 1, 0.4, None),
+            Err(ColumnError::InvalidPoints(_))
+        ));
+    }
+
+    #[test]
+    fn test_column_invalid_porosity() {
+        assert!(matches!(
+            Column::new(0.25, 100, 0.0, None),
+            Err(ColumnError::InvalidPorosity(_))
+        ));
+        assert!(matches!(
+            Column::new(0.25, 100, 1.0, None),
+            Err(ColumnError::InvalidPorosity(_))
+        ));
+        assert!(matches!(
+            Column::new(0.25, 100, 1.5, None),
+            Err(ColumnError::InvalidPorosity(_))
+        ));
+    }
+
+    #[test]
+    fn test_column_invalid_diameter() {
+        assert!(matches!(
+            Column::new(0.25, 100, 0.4, Some(0.0)),
+            Err(ColumnError::InvalidDiameter(_))
+        ));
+        assert!(matches!(
+            Column::new(0.25, 100, 0.4, Some(-0.01)),
+            Err(ColumnError::InvalidDiameter(_))
+        ));
+    }
+
+    #[test]
+    fn test_dz() {
+        let col = Column::new(0.25, 100, 0.4, None).unwrap();
+        assert!((col.dz() - 0.0025).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_phase_ratio() {
+        let col = Column::new(0.25, 100, 0.4, None).unwrap();
+        // Fe = (1 - 0.4) / 0.4 = 1.5
+        assert!((col.phase_ratio() - 1.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_column_serde_roundtrip() {
+        let col = Column::new(0.25, 100, 0.4, Some(0.01)).unwrap();
+        let json = serde_json::to_string(&col).unwrap();
+        let col2: Column = serde_json::from_str(&json).unwrap();
+        assert_eq!(col.column_length, col2.column_length);
+        assert_eq!(col.n_points, col2.n_points);
+        assert!((col.porosity - col2.porosity).abs() < 1e-12);
+        assert_eq!(col.diameter, col2.diameter);
+    }
+}

--- a/src/domain/column.rs
+++ b/src/domain/column.rs
@@ -1,11 +1,10 @@
-//! Colonne chromatographique — physical geometry of the chromatographic column.
+//! Physical geometry of the chromatographic column.
 //!
-//! Ce module définit [`Column`], le type canonique décrivant la géométrie
-//! physique d'une colonne chromatographique. Il est indépendant de tout
-//! modèle mathématique et sert de couche de construction validée pour
-//! [`LangmuirSingle`](crate::models::LangmuirSingle) et
-//! [`LangmuirMulti`](crate::models::LangmuirMulti), ainsi que pour tout
-//! futur modèle de transport.
+//! This module defines [`Column`], the canonical type describing the physical
+//! geometry of a chromatographic column. It is independent of any mathematical
+//! model and serves as a validated construction facade for
+//! [`LangmuirSingle`](crate::models::LangmuirSingle),
+//! [`LangmuirMulti`](crate::models::LangmuirMulti), and any future transport model.
 //!
 //! # Physical background
 //!
@@ -44,20 +43,19 @@ use std::fmt;
 // ColumnError
 // =============================================================================
 
-/// Erreurs de construction d'une [`Column`] — Column construction errors.
+/// Errors returned by [`Column::new`] when a physical constraint is violated.
 #[derive(Debug)]
 pub enum ColumnError {
-    /// La longueur doit être strictement positive — column length must be > 0.
+    /// Column length must be strictly positive ($L > 0$).
     InvalidLength(f64),
 
-    /// Le nombre de points doit être ≥ 2 — spatial points must be ≥ 2.
+    /// Number of spatial nodes must be at least 2 ($N_z \geq 2$).
     InvalidPoints(usize),
 
-    /// La porosité doit appartenir à (0, 1) — porosity must be in (0, 1).
+    /// Extragranular porosity must lie in the open interval $(0, 1)$.
     InvalidPorosity(f64),
 
-    /// Le diamètre, s'il est fourni, doit être strictement positif.
-    /// Diameter, when provided, must be > 0.
+    /// Inner diameter, when provided, must be strictly positive ($d > 0$).
     InvalidDiameter(f64),
 }
 
@@ -86,12 +84,12 @@ impl std::error::Error for ColumnError {}
 // Column
 // =============================================================================
 
-/// Géométrie physique d'une colonne chromatographique.
+/// Physical geometry of a chromatographic column.
 ///
-/// `Column` encapsule les paramètres géométriques et de discrétisation d'une
-/// colonne. Il sert de façade de construction validée : les modèles physiques
-/// (`LangmuirSingle`, `LangmuirMulti`, …) acceptent une `&Column` dans leur
-/// constructeur `from_domain` et en extraient les champs nécessaires.
+/// `Column` encapsulates the geometric and discretisation parameters of a
+/// column. It acts as a validated construction facade: physical models
+/// (`LangmuirSingle`, `LangmuirMulti`, …) accept a `&Column` in their
+/// `from_domain` constructor and extract the fields they need.
 ///
 /// # Fields
 ///
@@ -113,20 +111,23 @@ impl std::error::Error for ColumnError {}
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Column {
-    /// Longueur de la colonne $L$ \[m\] — column length.
+    /// Column length $L$ \[m\].
     pub column_length: f64,
 
-    /// Nombre de nœuds spatiaux $N_z$ — number of spatial discretisation nodes.
+    /// Number of spatial discretisation nodes $N_z$.
     pub n_points: usize,
 
-    /// Porosité extragranulaire $\varepsilon_e \in (0, 1)$ — extragranular porosity.
+    /// Extragranular porosity $\varepsilon_e \in (0, 1)$.
+    ///
+    /// Fraction de vide disponible pour la phase mobile entre les grains.
+    /// Void fraction available to the mobile phase between stationary-phase particles.
     pub porosity: f64,
 
-    /// Diamètre interne $d$ \[m\] — inner diameter (optional).
+    /// Inner diameter $d$ \[m\] (optional).
     ///
     /// Requis uniquement pour convertir un débit volumique $F$ en vitesse
-    /// superficielle $u$. Required only to convert volumetric flow rate to
-    /// superficial velocity.
+    /// superficielle $u = F / (\pi d^2 / 4)$.
+    /// Required only to convert volumetric flow rate to superficial velocity.
     pub diameter: Option<f64>,
 }
 
@@ -135,8 +136,6 @@ impl Column {
     // Constructor
     // =========================================================================
 
-    /// Construit une colonne après validation des paramètres.
-    ///
     /// Creates a validated column.
     ///
     /// # Arguments
@@ -193,9 +192,7 @@ impl Column {
     // Derived accessors
     // =========================================================================
 
-    /// Largeur d'une cellule spatiale $\Delta z = L / N_z$ \[m\].
-    ///
-    /// Spatial cell width.
+    /// Spatial cell width $\Delta z = L / N_z$ \[m\].
     ///
     /// # Example
     ///
@@ -210,9 +207,9 @@ impl Column {
         self.column_length / self.n_points as f64
     }
 
-    /// Rapport de phase $F_e = (1 - \varepsilon_e) / \varepsilon_e$.
+    /// Phase ratio $F_e = (1 - \varepsilon_e) / \varepsilon_e$.
     ///
-    /// Phase ratio — ratio of stationary-phase volume to mobile-phase volume.
+    /// Ratio of stationary-phase volume to mobile-phase volume.
     ///
     /// # Example
     ///

--- a/src/domain/detector.rs
+++ b/src/domain/detector.rs
@@ -1,33 +1,33 @@
-//! Détecteur chromatographique — chromatographic signal detector.
+//! Chromatographic signal detector.
 //!
-//! Ce module définit [`Detector`] et [`DetectorPosition`], qui spécifient
-//! l'emplacement du détecteur le long de l'axe de la colonne.
+//! This module defines [`Detector`] and [`DetectorPosition`], which specify
+//! the location of the measurement point along the column axis.
 //!
 //! # Physical background
 //!
-//! En chromatographie, le signal mesuré est la concentration en phase mobile
-//! au point de détection $z_d$. La position par défaut est la sortie de
-//! colonne ($z_d = L$), mais certains montages expérimentaux placent le
-//! détecteur en un point intermédiaire.
+//! In chromatography, the measured signal is the mobile-phase concentration
+//! at the detection point $z_d$. The default position is the column outlet
+//! ($z_d = L$), but some experimental setups place the detector at an
+//! intermediate point along the column.
 //!
 //! # Position variants
 //!
-//! | Variante | Description | Contrainte |
-//! |----------|-------------|-----------|
-//! | [`Outlet`](DetectorPosition::Outlet) | Sortie de colonne $z_d = L$ | aucune |
+//! | Variant | Description | Constraint |
+//! |---------|-------------|-----------|
+//! | [`Outlet`](DetectorPosition::Outlet) | Column outlet $z_d = L$ | none |
 //! | [`Relative`](DetectorPosition::Relative) | $z_d = r \cdot L$, $r \in [0, 1]$ | $r \in [0, 1]$ |
-//! | [`Absolute`](DetectorPosition::Absolute) | $z_d$ \[m\] | $z_d > 0$, validé contre $L$ à l'usage |
+//! | [`Absolute`](DetectorPosition::Absolute) | $z_d$ \[m\] | $z_d > 0$, validated against $L$ at use time |
 //!
 //! # Example
 //!
 //! ```rust
 //! use chrom_rs::domain::{Detector, DetectorPosition};
 //!
-//! // Détecteur en sortie de colonne (comportement actuel)
+//! // Detector at column outlet (current default behaviour)
 //! let det = Detector::outlet();
 //! assert!(matches!(det.position, DetectorPosition::Outlet));
 //!
-//! // Détecteur à mi-colonne
+//! // Detector at mid-column
 //! let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
 //! assert!((det.absolute_position(0.25) - 0.125).abs() < 1e-12);
 //! ```
@@ -39,19 +39,16 @@ use std::fmt;
 // DetectorError
 // =============================================================================
 
-/// Erreurs de construction d'un [`Detector`] — Detector construction errors.
+/// Errors returned by [`Detector::new`] or [`Detector::validate_against_column`].
 #[derive(Debug)]
 pub enum DetectorError {
-    /// La position relative doit appartenir à \[0, 1\].
-    /// Relative position must be in \[0, 1\].
+    /// Relative position must lie in $[0, 1]$.
     InvalidRelativePosition(f64),
 
-    /// La position absolue doit être strictement positive.
-    /// Absolute position must be > 0.
+    /// Absolute position must be strictly positive ($z_d > 0$).
     InvalidAbsolutePosition(f64),
 
-    /// La position absolue dépasse la longueur de la colonne.
-    /// Absolute position exceeds column length.
+    /// Absolute position exceeds the column length.
     PositionExceedsColumn { position: f64, column_length: f64 },
 }
 
@@ -83,22 +80,19 @@ impl std::error::Error for DetectorError {}
 // DetectorPosition
 // =============================================================================
 
-/// Position du détecteur le long de l'axe de la colonne.
-///
 /// Detector position along the column axis.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum DetectorPosition {
-    /// Sortie de colonne $z_d = L$ — column outlet (default behaviour).
+    /// Column outlet $z_d = L$ — default behaviour.
     Outlet,
 
-    /// Position relative $z_d = r \cdot L$, $r \in [0, 1]$.
-    ///
-    /// Relative position as a fraction of the column length.
+    /// Relative position $z_d = r \cdot L$, $r \in [0, 1]$.
     Relative(f64),
 
-    /// Position absolue $z_d$ \[m\] — absolute axial position.
+    /// Absolute axial position $z_d$ \[m\].
     ///
-    /// Doit être validée contre la longueur de la colonne avant usage.
+    /// Doit être validée contre la longueur de la colonne avant usage via
+    /// [`Detector::validate_against_column`].
     /// Must be validated against the column length before use.
     Absolute(f64),
 }
@@ -107,28 +101,28 @@ pub enum DetectorPosition {
 // Detector
 // =============================================================================
 
-/// Détecteur chromatographique à position configurable.
+/// Chromatographic detector with configurable position.
 ///
-/// `Detector` encapsule la position du point de mesure du signal. La position
-/// par défaut est la sortie de colonne ([`DetectorPosition::Outlet`]),
-/// reproduisant le comportement actuel de `outlet_data`.
+/// `Detector` encapsulates the measurement point along the column axis.
+/// The default position is the column outlet ([`DetectorPosition::Outlet`]),
+/// reproducing the behaviour of `outlet_data`.
 ///
 /// # Example
 ///
 /// ```rust
 /// use chrom_rs::domain::{Detector, DetectorPosition};
 ///
-/// // Sortie de colonne (défaut)
+/// // Column outlet (default)
 /// let det = Detector::outlet();
 ///
-/// // Mi-colonne
+/// // Mid-column detector
 /// let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
-/// // Pour L = 0.25 m : z_d = 0.125 m
+/// // For L = 0.25 m: z_d = 0.125 m
 /// assert!((det.absolute_position(0.25) - 0.125).abs() < 1e-12);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Detector {
-    /// Position du détecteur — detector position.
+    /// Detector position along the column axis.
     pub position: DetectorPosition,
 }
 
@@ -137,8 +131,6 @@ impl Detector {
     // Constructors
     // =========================================================================
 
-    /// Construit un détecteur après validation de la position.
-    ///
     /// Creates a validated detector.
     ///
     /// # Errors
@@ -147,9 +139,10 @@ impl Detector {
     /// - `Relative(r)` with $r \notin [0, 1]$
     /// - `Absolute(z)` with $z \leq 0$
     ///
-    /// Note : `Absolute(z)` n'est pas validé contre la longueur de colonne ici
-    /// (elle n'est pas connue à ce stade). Use [`validate_against_column`](Self::validate_against_column)
-    /// to check compatibility at simulation time.
+    /// Note: `Absolute(z)` is not validated against the column length here
+    /// (it is not known at construction time). Use
+    /// [`validate_against_column`](Self::validate_against_column) to check
+    /// compatibility at simulation time.
     ///
     /// # Example
     ///
@@ -185,10 +178,10 @@ impl Detector {
         Ok(Self { position })
     }
 
-    /// Construit un détecteur en sortie de colonne (comportement par défaut).
+    /// Creates a detector at the column outlet (default behaviour).
     ///
-    /// Creates an outlet detector (default behaviour — equivalent to current
-    /// `outlet_data` usage).
+    /// Equivalent to `Detector::new(DetectorPosition::Outlet)` — shorthand
+    /// for the most common case, reproducing the current `outlet_data` usage.
     ///
     /// # Example
     ///
@@ -208,12 +201,10 @@ impl Detector {
     // Accessors
     // =========================================================================
 
-    /// Retourne la position absolue $z_d$ \[m\] pour une longueur de colonne $L$ donnée.
-    ///
     /// Returns the absolute axial position $z_d$ \[m\] for a given column length $L$.
     ///
-    /// | Variante | Résultat |
-    /// |----------|---------|
+    /// | Variant | Result |
+    /// |---------|--------|
     /// | `Outlet` | $L$ |
     /// | `Relative(r)` | $r \cdot L$ |
     /// | `Absolute(z)` | $z$ |
@@ -239,10 +230,9 @@ impl Detector {
         }
     }
 
-    /// Valide la position absolue contre la longueur de la colonne.
+    /// Validates an `Absolute` position against the column length.
     ///
-    /// Validates an `Absolute` position against the column length. No-op for
-    /// `Outlet` and `Relative` variants.
+    /// No-op for `Outlet` and `Relative` variants.
     ///
     /// # Errors
     ///
@@ -270,27 +260,25 @@ impl Detector {
         Ok(())
     }
 
-    /// Retourne l'indice spatial du nœud le plus proche de la position du détecteur.
-    ///
     /// Returns the spatial node index closest to the detector position.
     ///
-    /// Utilisé pour extraire le signal depuis un profil de concentration discrétisé.
     /// Used to extract the signal from a discretised concentration profile.
+    /// Utilisé pour extraire le signal depuis un profil de concentration discrétisé.
     ///
     /// # Arguments
     ///
-    /// * `column_length` — longueur de la colonne $L$ \[m\]
-    /// * `n_points`      — nombre de nœuds spatiaux $N_z$
+    /// * `column_length` — column length $L$ \[m\]
+    /// * `n_points`      — number of spatial nodes $N_z$
     ///
     /// # Example
     ///
     /// ```rust
     /// use chrom_rs::domain::{Detector, DetectorPosition};
     ///
-    /// // Sortie de colonne → dernier nœud
+    /// // Outlet → last node
     /// assert_eq!(Detector::outlet().node_index(0.25, 100), 99);
     ///
-    /// // Mi-colonne → nœud 50
+    /// // Mid-column → node 50
     /// let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
     /// assert_eq!(det.node_index(0.25, 100), 50);
     /// ```
@@ -303,8 +291,6 @@ impl Detector {
 }
 
 impl Default for Detector {
-    /// Détecteur par défaut : sortie de colonne.
-    ///
     /// Default detector: column outlet.
     fn default() -> Self {
         Self::outlet()
@@ -395,7 +381,7 @@ mod tests {
 
     #[test]
     fn test_validate_outlet_always_ok() {
-        // Outlet et Relative ne sont jamais rejetés par validate_against_column
+        // Outlet and Relative are never rejected by validate_against_column
         assert!(Detector::outlet().validate_against_column(0.01).is_ok());
         let det = Detector::new(DetectorPosition::Relative(0.9)).unwrap();
         assert!(det.validate_against_column(0.01).is_ok());
@@ -415,6 +401,7 @@ mod tests {
     #[test]
     fn test_node_index_clamped() {
         // Position absolue légèrement supérieure au dernier nœud → clamp
+        // Absolute position slightly beyond the last node → clamped to n_points - 1
         let det = Detector::new(DetectorPosition::Absolute(0.25)).unwrap();
         assert_eq!(det.node_index(0.25, 100), 99);
     }

--- a/src/domain/detector.rs
+++ b/src/domain/detector.rs
@@ -1,0 +1,435 @@
+//! Détecteur chromatographique — chromatographic signal detector.
+//!
+//! Ce module définit [`Detector`] et [`DetectorPosition`], qui spécifient
+//! l'emplacement du détecteur le long de l'axe de la colonne.
+//!
+//! # Physical background
+//!
+//! En chromatographie, le signal mesuré est la concentration en phase mobile
+//! au point de détection $z_d$. La position par défaut est la sortie de
+//! colonne ($z_d = L$), mais certains montages expérimentaux placent le
+//! détecteur en un point intermédiaire.
+//!
+//! # Position variants
+//!
+//! | Variante | Description | Contrainte |
+//! |----------|-------------|-----------|
+//! | [`Outlet`](DetectorPosition::Outlet) | Sortie de colonne $z_d = L$ | aucune |
+//! | [`Relative`](DetectorPosition::Relative) | $z_d = r \cdot L$, $r \in [0, 1]$ | $r \in [0, 1]$ |
+//! | [`Absolute`](DetectorPosition::Absolute) | $z_d$ \[m\] | $z_d > 0$, validé contre $L$ à l'usage |
+//!
+//! # Example
+//!
+//! ```rust
+//! use chrom_rs::domain::{Detector, DetectorPosition};
+//!
+//! // Détecteur en sortie de colonne (comportement actuel)
+//! let det = Detector::outlet();
+//! assert!(matches!(det.position, DetectorPosition::Outlet));
+//!
+//! // Détecteur à mi-colonne
+//! let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+//! assert!((det.absolute_position(0.25) - 0.125).abs() < 1e-12);
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// =============================================================================
+// DetectorError
+// =============================================================================
+
+/// Erreurs de construction d'un [`Detector`] — Detector construction errors.
+#[derive(Debug)]
+pub enum DetectorError {
+    /// La position relative doit appartenir à \[0, 1\].
+    /// Relative position must be in \[0, 1\].
+    InvalidRelativePosition(f64),
+
+    /// La position absolue doit être strictement positive.
+    /// Absolute position must be > 0.
+    InvalidAbsolutePosition(f64),
+
+    /// La position absolue dépasse la longueur de la colonne.
+    /// Absolute position exceeds column length.
+    PositionExceedsColumn { position: f64, column_length: f64 },
+}
+
+impl fmt::Display for DetectorError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DetectorError::InvalidRelativePosition(r) => {
+                write!(f, "detector: relative position must be in [0, 1], got {r}")
+            }
+            DetectorError::InvalidAbsolutePosition(z) => {
+                write!(f, "detector: absolute position must be > 0, got {z}")
+            }
+            DetectorError::PositionExceedsColumn {
+                position,
+                column_length,
+            } => {
+                write!(
+                    f,
+                    "detector: position {position} m exceeds column length {column_length} m"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for DetectorError {}
+
+// =============================================================================
+// DetectorPosition
+// =============================================================================
+
+/// Position du détecteur le long de l'axe de la colonne.
+///
+/// Detector position along the column axis.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub enum DetectorPosition {
+    /// Sortie de colonne $z_d = L$ — column outlet (default behaviour).
+    Outlet,
+
+    /// Position relative $z_d = r \cdot L$, $r \in [0, 1]$.
+    ///
+    /// Relative position as a fraction of the column length.
+    Relative(f64),
+
+    /// Position absolue $z_d$ \[m\] — absolute axial position.
+    ///
+    /// Doit être validée contre la longueur de la colonne avant usage.
+    /// Must be validated against the column length before use.
+    Absolute(f64),
+}
+
+// =============================================================================
+// Detector
+// =============================================================================
+
+/// Détecteur chromatographique à position configurable.
+///
+/// `Detector` encapsule la position du point de mesure du signal. La position
+/// par défaut est la sortie de colonne ([`DetectorPosition::Outlet`]),
+/// reproduisant le comportement actuel de `outlet_data`.
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::domain::{Detector, DetectorPosition};
+///
+/// // Sortie de colonne (défaut)
+/// let det = Detector::outlet();
+///
+/// // Mi-colonne
+/// let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+/// // Pour L = 0.25 m : z_d = 0.125 m
+/// assert!((det.absolute_position(0.25) - 0.125).abs() < 1e-12);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Detector {
+    /// Position du détecteur — detector position.
+    pub position: DetectorPosition,
+}
+
+impl Detector {
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+
+    /// Construit un détecteur après validation de la position.
+    ///
+    /// Creates a validated detector.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DetectorError`] if:
+    /// - `Relative(r)` with $r \notin [0, 1]$
+    /// - `Absolute(z)` with $z \leq 0$
+    ///
+    /// Note : `Absolute(z)` n'est pas validé contre la longueur de colonne ici
+    /// (elle n'est pas connue à ce stade). Use [`validate_against_column`](Self::validate_against_column)
+    /// to check compatibility at simulation time.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Detector, DetectorPosition, DetectorError};
+    ///
+    /// assert!(Detector::new(DetectorPosition::Outlet).is_ok());
+    /// assert!(Detector::new(DetectorPosition::Relative(0.5)).is_ok());
+    /// assert!(Detector::new(DetectorPosition::Absolute(0.1)).is_ok());
+    /// assert!(matches!(
+    ///     Detector::new(DetectorPosition::Relative(1.5)),
+    ///     Err(DetectorError::InvalidRelativePosition(_))
+    /// ));
+    /// assert!(matches!(
+    ///     Detector::new(DetectorPosition::Absolute(-0.1)),
+    ///     Err(DetectorError::InvalidAbsolutePosition(_))
+    /// ));
+    /// ```
+    pub fn new(position: DetectorPosition) -> Result<Self, DetectorError> {
+        match &position {
+            DetectorPosition::Outlet => {}
+            DetectorPosition::Relative(r) => {
+                if *r < 0.0 || *r > 1.0 {
+                    return Err(DetectorError::InvalidRelativePosition(*r));
+                }
+            }
+            DetectorPosition::Absolute(z) => {
+                if *z <= 0.0 {
+                    return Err(DetectorError::InvalidAbsolutePosition(*z));
+                }
+            }
+        }
+        Ok(Self { position })
+    }
+
+    /// Construit un détecteur en sortie de colonne (comportement par défaut).
+    ///
+    /// Creates an outlet detector (default behaviour — equivalent to current
+    /// `outlet_data` usage).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Detector, DetectorPosition};
+    ///
+    /// let det = Detector::outlet();
+    /// assert_eq!(det.position, DetectorPosition::Outlet);
+    /// ```
+    pub fn outlet() -> Self {
+        Self {
+            position: DetectorPosition::Outlet,
+        }
+    }
+
+    // =========================================================================
+    // Accessors
+    // =========================================================================
+
+    /// Retourne la position absolue $z_d$ \[m\] pour une longueur de colonne $L$ donnée.
+    ///
+    /// Returns the absolute axial position $z_d$ \[m\] for a given column length $L$.
+    ///
+    /// | Variante | Résultat |
+    /// |----------|---------|
+    /// | `Outlet` | $L$ |
+    /// | `Relative(r)` | $r \cdot L$ |
+    /// | `Absolute(z)` | $z$ |
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Detector, DetectorPosition};
+    ///
+    /// assert!((Detector::outlet().absolute_position(0.25) - 0.25).abs() < 1e-12);
+    ///
+    /// let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+    /// assert!((det.absolute_position(0.25) - 0.125).abs() < 1e-12);
+    ///
+    /// let det = Detector::new(DetectorPosition::Absolute(0.1)).unwrap();
+    /// assert!((det.absolute_position(0.25) - 0.1).abs() < 1e-12);
+    /// ```
+    pub fn absolute_position(&self, column_length: f64) -> f64 {
+        match &self.position {
+            DetectorPosition::Outlet => column_length,
+            DetectorPosition::Relative(r) => r * column_length,
+            DetectorPosition::Absolute(z) => *z,
+        }
+    }
+
+    /// Valide la position absolue contre la longueur de la colonne.
+    ///
+    /// Validates an `Absolute` position against the column length. No-op for
+    /// `Outlet` and `Relative` variants.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DetectorError::PositionExceedsColumn`] if the absolute
+    /// position exceeds `column_length`.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Detector, DetectorPosition, DetectorError};
+    ///
+    /// let det = Detector::new(DetectorPosition::Absolute(0.3)).unwrap();
+    /// assert!(det.validate_against_column(0.25).is_err());
+    /// assert!(det.validate_against_column(0.50).is_ok());
+    /// ```
+    pub fn validate_against_column(&self, column_length: f64) -> Result<(), DetectorError> {
+        if let DetectorPosition::Absolute(z) = &self.position
+            && *z > column_length
+        {
+            return Err(DetectorError::PositionExceedsColumn {
+                position: *z,
+                column_length,
+            });
+        }
+        Ok(())
+    }
+
+    /// Retourne l'indice spatial du nœud le plus proche de la position du détecteur.
+    ///
+    /// Returns the spatial node index closest to the detector position.
+    ///
+    /// Utilisé pour extraire le signal depuis un profil de concentration discrétisé.
+    /// Used to extract the signal from a discretised concentration profile.
+    ///
+    /// # Arguments
+    ///
+    /// * `column_length` — longueur de la colonne $L$ \[m\]
+    /// * `n_points`      — nombre de nœuds spatiaux $N_z$
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Detector, DetectorPosition};
+    ///
+    /// // Sortie de colonne → dernier nœud
+    /// assert_eq!(Detector::outlet().node_index(0.25, 100), 99);
+    ///
+    /// // Mi-colonne → nœud 50
+    /// let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+    /// assert_eq!(det.node_index(0.25, 100), 50);
+    /// ```
+    pub fn node_index(&self, column_length: f64, n_points: usize) -> usize {
+        let z = self.absolute_position(column_length);
+        let dz = column_length / n_points as f64;
+        let idx = (z / dz).round() as usize;
+        idx.min(n_points - 1)
+    }
+}
+
+impl Default for Detector {
+    /// Détecteur par défaut : sortie de colonne.
+    ///
+    /// Default detector: column outlet.
+    fn default() -> Self {
+        Self::outlet()
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detector_outlet() {
+        let det = Detector::outlet();
+        assert_eq!(det.position, DetectorPosition::Outlet);
+    }
+
+    #[test]
+    fn test_detector_relative_valid() {
+        assert!(Detector::new(DetectorPosition::Relative(0.0)).is_ok());
+        assert!(Detector::new(DetectorPosition::Relative(0.5)).is_ok());
+        assert!(Detector::new(DetectorPosition::Relative(1.0)).is_ok());
+    }
+
+    #[test]
+    fn test_detector_relative_invalid() {
+        assert!(matches!(
+            Detector::new(DetectorPosition::Relative(-0.1)),
+            Err(DetectorError::InvalidRelativePosition(_))
+        ));
+        assert!(matches!(
+            Detector::new(DetectorPosition::Relative(1.1)),
+            Err(DetectorError::InvalidRelativePosition(_))
+        ));
+    }
+
+    #[test]
+    fn test_detector_absolute_valid() {
+        assert!(Detector::new(DetectorPosition::Absolute(0.1)).is_ok());
+    }
+
+    #[test]
+    fn test_detector_absolute_invalid() {
+        assert!(matches!(
+            Detector::new(DetectorPosition::Absolute(0.0)),
+            Err(DetectorError::InvalidAbsolutePosition(_))
+        ));
+        assert!(matches!(
+            Detector::new(DetectorPosition::Absolute(-0.1)),
+            Err(DetectorError::InvalidAbsolutePosition(_))
+        ));
+    }
+
+    #[test]
+    fn test_absolute_position_outlet() {
+        assert!((Detector::outlet().absolute_position(0.25) - 0.25).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_absolute_position_relative() {
+        let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+        assert!((det.absolute_position(0.25) - 0.125).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_absolute_position_absolute() {
+        let det = Detector::new(DetectorPosition::Absolute(0.1)).unwrap();
+        assert!((det.absolute_position(0.25) - 0.1).abs() < 1e-12);
+    }
+
+    #[test]
+    fn test_validate_against_column_ok() {
+        let det = Detector::new(DetectorPosition::Absolute(0.1)).unwrap();
+        assert!(det.validate_against_column(0.25).is_ok());
+    }
+
+    #[test]
+    fn test_validate_against_column_exceeds() {
+        let det = Detector::new(DetectorPosition::Absolute(0.3)).unwrap();
+        assert!(matches!(
+            det.validate_against_column(0.25),
+            Err(DetectorError::PositionExceedsColumn { .. })
+        ));
+    }
+
+    #[test]
+    fn test_validate_outlet_always_ok() {
+        // Outlet et Relative ne sont jamais rejetés par validate_against_column
+        assert!(Detector::outlet().validate_against_column(0.01).is_ok());
+        let det = Detector::new(DetectorPosition::Relative(0.9)).unwrap();
+        assert!(det.validate_against_column(0.01).is_ok());
+    }
+
+    #[test]
+    fn test_node_index_outlet() {
+        assert_eq!(Detector::outlet().node_index(0.25, 100), 99);
+    }
+
+    #[test]
+    fn test_node_index_relative_half() {
+        let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+        assert_eq!(det.node_index(0.25, 100), 50);
+    }
+
+    #[test]
+    fn test_node_index_clamped() {
+        // Position absolue légèrement supérieure au dernier nœud → clamp
+        let det = Detector::new(DetectorPosition::Absolute(0.25)).unwrap();
+        assert_eq!(det.node_index(0.25, 100), 99);
+    }
+
+    #[test]
+    fn test_detector_default() {
+        let det = Detector::default();
+        assert_eq!(det.position, DetectorPosition::Outlet);
+    }
+
+    #[test]
+    fn test_detector_serde_roundtrip() {
+        let det = Detector::new(DetectorPosition::Relative(0.5)).unwrap();
+        let json = serde_json::to_string(&det).unwrap();
+        let det2: Detector = serde_json::from_str(&json).unwrap();
+        assert_eq!(det.position, det2.position);
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -15,10 +15,10 @@
 //!
 //! | Module | Primary type | Role |
 //! |--------|-------------|------|
-//! | [`column`] | [`Column`] | Column geometry |
-//! | [`phases`] | [`MobilePhase`] | Mobile-phase properties |
-//! | [`sample`] | [`Sample`] | Inlet injection profiles |
-//! | [`detector`] | [`Detector`] | Signal measurement point |
+//! | `column` | [`Column`](crate::domain::Column) | Column geometry |
+//! | `phases` | [`MobilePhase`](crate::domain::MobilePhase) | Mobile-phase properties |
+//! | `sample` | [`Sample`](crate::domain::Sample) | Inlet injection profiles |
+//! | `detector` | [`Detector`](crate::domain::Detector) | Signal measurement point |
 //!
 //! # Example
 //!

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,44 @@
+//! Modèle du domaine — physical domain model.
+//!
+//! Ce module regroupe les types décrivant l'**équipement physique** d'un
+//! système chromatographique, indépendamment du modèle mathématique choisi
+//! (Langmuir, diffusion dans les pores, etc.).
+//!
+//! # Design (DD-011)
+//!
+//! `domain/` est une **façade de construction validée** : ses types
+//! encapsulent et valident les paramètres physiques, puis les transmettent
+//! aux modèles via le constructeur `from_domain`. Les modèles conservent
+//! leurs champs internes — la migration de la propriété des données vers
+//! `domain/` est différée à un jalon futur.
+//!
+//! # Modules
+//!
+//! | Module | Type principal | Rôle |
+//! |--------|---------------|------|
+//! | [`column`] | [`Column`] | Géométrie de la colonne |
+//! | [`phases`] | [`MobilePhase`] | Propriétés de la phase mobile |
+//! | [`sample`] | [`Sample`] | Profils d'injection à l'entrée |
+//! | [`detector`] | [`Detector`] | Position du point de mesure |
+//!
+//! # Example
+//!
+//! ```rust
+//! use chrom_rs::domain::{Column, MobilePhase, Sample, Detector};
+//! use chrom_rs::models::TemporalInjection;
+//!
+//! let column = Column::new(0.25, 100, 0.4, None).unwrap();
+//! let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+//! let sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+//! let detector = Detector::outlet();
+//! ```
+
+pub mod column;
+pub mod detector;
+pub mod phases;
+pub mod sample;
+
+pub use column::{Column, ColumnError};
+pub use detector::{Detector, DetectorError, DetectorPosition};
+pub use phases::{MobilePhase, MobilePhaseError};
+pub use sample::Sample;

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,25 +1,24 @@
-//! Modèle du domaine — physical domain model.
+//! Physical domain model — equipment description layer.
 //!
-//! Ce module regroupe les types décrivant l'**équipement physique** d'un
-//! système chromatographique, indépendamment du modèle mathématique choisi
-//! (Langmuir, diffusion dans les pores, etc.).
+//! This module groups the types describing the **physical equipment** of a
+//! chromatographic system, independent of the mathematical model chosen
+//! (Langmuir, pore-diffusion, dispersive, etc.).
 //!
 //! # Design (DD-011)
 //!
-//! `domain/` est une **façade de construction validée** : ses types
-//! encapsulent et valident les paramètres physiques, puis les transmettent
-//! aux modèles via le constructeur `from_domain`. Les modèles conservent
-//! leurs champs internes — la migration de la propriété des données vers
-//! `domain/` est différée à un jalon futur.
+//! `domain/` is a **validated construction facade**: its types encapsulate and
+//! validate physical parameters, then pass them to models via the
+//! `from_domain` constructor. Models retain their internal fields — migration
+//! of data ownership to `domain/` is deferred to a future milestone.
 //!
 //! # Modules
 //!
-//! | Module | Type principal | Rôle |
-//! |--------|---------------|------|
-//! | [`column`] | [`Column`] | Géométrie de la colonne |
-//! | [`phases`] | [`MobilePhase`] | Propriétés de la phase mobile |
-//! | [`sample`] | [`Sample`] | Profils d'injection à l'entrée |
-//! | [`detector`] | [`Detector`] | Position du point de mesure |
+//! | Module | Primary type | Role |
+//! |--------|-------------|------|
+//! | [`column`] | [`Column`] | Column geometry |
+//! | [`phases`] | [`MobilePhase`] | Mobile-phase properties |
+//! | [`sample`] | [`Sample`] | Inlet injection profiles |
+//! | [`detector`] | [`Detector`] | Signal measurement point |
 //!
 //! # Example
 //!

--- a/src/domain/phases.rs
+++ b/src/domain/phases.rs
@@ -1,46 +1,44 @@
-//! Phases chromatographiques — chromatographic phases.
+//! Chromatographic phases.
 //!
-//! Ce module regroupe les types décrivant les phases présentes dans un
-//! système chromatographique. Seule la **phase mobile** est modélisée en
-//! v0.3.0 ; d'autres phases (gradient d'élution, phases couplées) pourront
-//! être ajoutées ici dans les jalons futurs.
+//! This module groups the types describing the phases present in a
+//! chromatographic system. Only the **mobile phase** is modelled in v0.3.0;
+//! additional phases (gradient elution, coupled columns) may be added here
+//! in future milestones.
 //!
 //! # Structure
 //!
-//! | Type | Rôle |
+//! | Type | Role |
 //! |------|------|
-//! | [`MobilePhase`] | Solvant porteur — carrier fluid properties |
+//! | [`MobilePhase`] | Carrier fluid properties |
 //!
 //! # Physical background
 //!
-//! La **phase mobile** est le solvant qui circule à travers la colonne et
-//! transporte les solutés. Ses paramètres clés sont la vitesse superficielle
-//! $u$ et, optionnellement, la viscosité dynamique $\eta$.
+//! The **mobile phase** is the solvent flowing through the column that
+//! carries the solutes. Its key parameters are the superficial velocity $u$
+//! and, optionally, the dynamic viscosity $\eta$.
 //!
-//! La **vitesse interstitielle** $u_e = u / \varepsilon_e$ est la vitesse
-//! réelle du fluide entre les grains — elle gouverne le transport convectif
-//! dans les équations de conservation.
+//! The **interstitial velocity** $u_e = u / \varepsilon_e$ is the actual fluid
+//! velocity between the stationary-phase particles — it governs convective
+//! transport in the conservation equations.
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
 // =============================================================================
-// Section : Mobile Phase
+// Section: Mobile Phase
 // =============================================================================
 
 // -----------------------------------------------------------------------------
 // MobilePhaseError
 // -----------------------------------------------------------------------------
 
-/// Erreurs de construction d'une [`MobilePhase`] — MobilePhase construction errors.
+/// Errors returned by [`MobilePhase::new`] when a physical constraint is violated.
 #[derive(Debug)]
 pub enum MobilePhaseError {
-    /// La vitesse superficielle doit être strictement positive.
-    /// Superficial velocity must be > 0.
+    /// Superficial velocity must be strictly positive ($u > 0$).
     InvalidVelocity(f64),
 
-    /// La viscosité, si fournie, doit être strictement positive.
-    /// Viscosity, when provided, must be > 0.
+    /// Dynamic viscosity, when provided, must be strictly positive ($\eta > 0$).
     InvalidViscosity(f64),
 }
 
@@ -63,11 +61,11 @@ impl std::error::Error for MobilePhaseError {}
 // MobilePhase
 // -----------------------------------------------------------------------------
 
-/// Phase mobile d'un système chromatographique.
+/// Carrier fluid properties of a chromatographic system.
 ///
-/// `MobilePhase` encapsule les propriétés du solvant porteur. Elle est
-/// indépendante du modèle mathématique et sert de façade de construction
-/// validée pour les modèles physiques via leur constructeur `from_domain`.
+/// `MobilePhase` encapsulates the properties of the carrier solvent. It is
+/// independent of the mathematical model and serves as a validated construction
+/// facade for physical models via their `from_domain` constructor.
 ///
 /// # Fields
 ///
@@ -82,22 +80,22 @@ impl std::error::Error for MobilePhaseError {}
 /// use chrom_rs::domain::MobilePhase;
 ///
 /// let mp = MobilePhase::new(1e-4, None).unwrap();
-/// // Vitesse interstitielle pour ε_e = 0.4
+/// // Interstitial velocity for ε_e = 0.4
 /// assert!((mp.interstitial_velocity(0.4) - 2.5e-4).abs() < 1e-15);
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MobilePhase {
-    /// Vitesse superficielle $u$ \[m/s\] — superficial velocity.
+    /// Superficial velocity $u$ \[m/s\].
     ///
     /// Vitesse du solvant rapportée à la section totale de la colonne
-    /// (vides + solide). The carrier velocity referred to the total
-    /// column cross-section.
+    /// (vides + solide). Carrier velocity referred to the total column
+    /// cross-section (voids + solid).
     pub velocity: f64,
 
-    /// Viscosité dynamique $\eta$ \[Pa·s\] — dynamic viscosity (optional).
+    /// Dynamic viscosity $\eta$ \[Pa·s\] (optional).
     ///
-    /// Requise uniquement pour les calculs de perte de charge. Required
-    /// only for pressure-drop calculations.
+    /// Requise uniquement pour les calculs de perte de charge.
+    /// Required only for pressure-drop calculations.
     pub viscosity: Option<f64>,
 }
 
@@ -106,8 +104,6 @@ impl MobilePhase {
     // Constructor
     // =========================================================================
 
-    /// Construit une phase mobile après validation des paramètres.
-    ///
     /// Creates a validated mobile phase.
     ///
     /// # Arguments
@@ -154,9 +150,9 @@ impl MobilePhase {
     // Derived accessors
     // =========================================================================
 
-    /// Vitesse interstitielle $u_e = u / \varepsilon_e$ \[m/s\].
+    /// Interstitial velocity $u_e = u / \varepsilon_e$ \[m/s\].
     ///
-    /// Interstitial velocity — the actual fluid velocity between particles.
+    /// Actual fluid velocity between the stationary-phase particles.
     ///
     /// # Arguments
     ///
@@ -184,10 +180,6 @@ impl MobilePhase {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    // -------------------------------------------------------------------------
-    // MobilePhase
-    // -------------------------------------------------------------------------
 
     #[test]
     fn test_mobile_phase_valid() {

--- a/src/domain/phases.rs
+++ b/src/domain/phases.rs
@@ -1,0 +1,244 @@
+//! Phases chromatographiques — chromatographic phases.
+//!
+//! Ce module regroupe les types décrivant les phases présentes dans un
+//! système chromatographique. Seule la **phase mobile** est modélisée en
+//! v0.3.0 ; d'autres phases (gradient d'élution, phases couplées) pourront
+//! être ajoutées ici dans les jalons futurs.
+//!
+//! # Structure
+//!
+//! | Type | Rôle |
+//! |------|------|
+//! | [`MobilePhase`] | Solvant porteur — carrier fluid properties |
+//!
+//! # Physical background
+//!
+//! La **phase mobile** est le solvant qui circule à travers la colonne et
+//! transporte les solutés. Ses paramètres clés sont la vitesse superficielle
+//! $u$ et, optionnellement, la viscosité dynamique $\eta$.
+//!
+//! La **vitesse interstitielle** $u_e = u / \varepsilon_e$ est la vitesse
+//! réelle du fluide entre les grains — elle gouverne le transport convectif
+//! dans les équations de conservation.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+// =============================================================================
+// Section : Mobile Phase
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// MobilePhaseError
+// -----------------------------------------------------------------------------
+
+/// Erreurs de construction d'une [`MobilePhase`] — MobilePhase construction errors.
+#[derive(Debug)]
+pub enum MobilePhaseError {
+    /// La vitesse superficielle doit être strictement positive.
+    /// Superficial velocity must be > 0.
+    InvalidVelocity(f64),
+
+    /// La viscosité, si fournie, doit être strictement positive.
+    /// Viscosity, when provided, must be > 0.
+    InvalidViscosity(f64),
+}
+
+impl fmt::Display for MobilePhaseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MobilePhaseError::InvalidVelocity(v) => {
+                write!(f, "mobile phase: velocity must be > 0, got {v}")
+            }
+            MobilePhaseError::InvalidViscosity(v) => {
+                write!(f, "mobile phase: viscosity must be > 0, got {v}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for MobilePhaseError {}
+
+// -----------------------------------------------------------------------------
+// MobilePhase
+// -----------------------------------------------------------------------------
+
+/// Phase mobile d'un système chromatographique.
+///
+/// `MobilePhase` encapsule les propriétés du solvant porteur. Elle est
+/// indépendante du modèle mathématique et sert de façade de construction
+/// validée pour les modèles physiques via leur constructeur `from_domain`.
+///
+/// # Fields
+///
+/// | Field | Symbol | Unit | Constraint |
+/// |-------|--------|------|-----------|
+/// | `velocity` | $u$ | m/s | $> 0$ |
+/// | `viscosity` | $\eta$ | Pa·s | $> 0$ if `Some` |
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::domain::MobilePhase;
+///
+/// let mp = MobilePhase::new(1e-4, None).unwrap();
+/// // Vitesse interstitielle pour ε_e = 0.4
+/// assert!((mp.interstitial_velocity(0.4) - 2.5e-4).abs() < 1e-15);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MobilePhase {
+    /// Vitesse superficielle $u$ \[m/s\] — superficial velocity.
+    ///
+    /// Vitesse du solvant rapportée à la section totale de la colonne
+    /// (vides + solide). The carrier velocity referred to the total
+    /// column cross-section.
+    pub velocity: f64,
+
+    /// Viscosité dynamique $\eta$ \[Pa·s\] — dynamic viscosity (optional).
+    ///
+    /// Requise uniquement pour les calculs de perte de charge. Required
+    /// only for pressure-drop calculations.
+    pub viscosity: Option<f64>,
+}
+
+impl MobilePhase {
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
+    /// Construit une phase mobile après validation des paramètres.
+    ///
+    /// Creates a validated mobile phase.
+    ///
+    /// # Arguments
+    ///
+    /// * `velocity`  — $u$ \[m/s\], must be > 0
+    /// * `viscosity` — $\eta$ \[Pa·s\], must be > 0 when `Some`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MobilePhaseError`] if any constraint is violated.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{MobilePhase, MobilePhaseError};
+    ///
+    /// assert!(MobilePhase::new(1e-4, None).is_ok());
+    /// assert!(MobilePhase::new(1e-4, Some(1e-3)).is_ok());
+    /// assert!(matches!(
+    ///     MobilePhase::new(-1e-4, None),
+    ///     Err(MobilePhaseError::InvalidVelocity(_))
+    /// ));
+    /// assert!(matches!(
+    ///     MobilePhase::new(1e-4, Some(-1e-3)),
+    ///     Err(MobilePhaseError::InvalidViscosity(_))
+    /// ));
+    /// ```
+    pub fn new(velocity: f64, viscosity: Option<f64>) -> Result<Self, MobilePhaseError> {
+        if velocity <= 0.0 {
+            return Err(MobilePhaseError::InvalidVelocity(velocity));
+        }
+        if let Some(eta) = viscosity
+            && eta <= 0.0
+        {
+            return Err(MobilePhaseError::InvalidViscosity(eta));
+        }
+        Ok(Self {
+            velocity,
+            viscosity,
+        })
+    }
+
+    // =========================================================================
+    // Derived accessors
+    // =========================================================================
+
+    /// Vitesse interstitielle $u_e = u / \varepsilon_e$ \[m/s\].
+    ///
+    /// Interstitial velocity — the actual fluid velocity between particles.
+    ///
+    /// # Arguments
+    ///
+    /// * `porosity` — extragranular porosity $\varepsilon_e \in (0, 1)$
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::MobilePhase;
+    ///
+    /// let mp = MobilePhase::new(1e-4, None).unwrap();
+    /// // u_e = 1e-4 / 0.4 = 2.5e-4
+    /// assert!((mp.interstitial_velocity(0.4) - 2.5e-4).abs() < 1e-15);
+    /// ```
+    #[inline]
+    pub fn interstitial_velocity(&self, porosity: f64) -> f64 {
+        self.velocity / porosity
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // MobilePhase
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_mobile_phase_valid() {
+        let mp = MobilePhase::new(1e-4, None).unwrap();
+        assert!((mp.velocity - 1e-4).abs() < 1e-15);
+        assert!(mp.viscosity.is_none());
+    }
+
+    #[test]
+    fn test_mobile_phase_with_viscosity() {
+        let mp = MobilePhase::new(1e-4, Some(1e-3)).unwrap();
+        assert!((mp.viscosity.unwrap() - 1e-3).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_mobile_phase_invalid_velocity() {
+        assert!(matches!(
+            MobilePhase::new(0.0, None),
+            Err(MobilePhaseError::InvalidVelocity(_))
+        ));
+        assert!(matches!(
+            MobilePhase::new(-1e-4, None),
+            Err(MobilePhaseError::InvalidVelocity(_))
+        ));
+    }
+
+    #[test]
+    fn test_mobile_phase_invalid_viscosity() {
+        assert!(matches!(
+            MobilePhase::new(1e-4, Some(0.0)),
+            Err(MobilePhaseError::InvalidViscosity(_))
+        ));
+        assert!(matches!(
+            MobilePhase::new(1e-4, Some(-1e-3)),
+            Err(MobilePhaseError::InvalidViscosity(_))
+        ));
+    }
+
+    #[test]
+    fn test_interstitial_velocity() {
+        let mp = MobilePhase::new(1e-4, None).unwrap();
+        // u_e = 1e-4 / 0.4 = 2.5e-4
+        assert!((mp.interstitial_velocity(0.4) - 2.5e-4).abs() < 1e-15);
+    }
+
+    #[test]
+    fn test_mobile_phase_serde_roundtrip() {
+        let mp = MobilePhase::new(1e-4, Some(1e-3)).unwrap();
+        let json = serde_json::to_string(&mp).unwrap();
+        let mp2: MobilePhase = serde_json::from_str(&json).unwrap();
+        assert!((mp.velocity - mp2.velocity).abs() < 1e-15);
+        assert!((mp.viscosity.unwrap() - mp2.viscosity.unwrap()).abs() < 1e-15);
+    }
+}

--- a/src/domain/sample.rs
+++ b/src/domain/sample.rs
@@ -5,7 +5,7 @@
 //!
 //! # Design
 //!
-//! `Sample` uses the same key/value scheme as [`PhysicalModel::set_injections`]:
+//! `Sample` uses the same key/value scheme as [`PhysicalModel::set_injections`](crate::physics::PhysicalModel::set_injections):
 //!
 //! | Key | Meaning |
 //! |-----|---------|
@@ -14,7 +14,7 @@
 //!
 //! This scheme is identical to the `HashMap<Option<String>, TemporalInjection>`
 //! already used inside `LangmuirSingle` and `LangmuirMulti`, and integrates
-//! directly with [`PhysicalModel::set_injections`].
+//! directly with [`PhysicalModel::set_injections`](crate::physics::PhysicalModel::set_injections).
 //!
 //! # Example
 //!
@@ -144,7 +144,7 @@ impl Sample {
     }
 
     /// Returns a reference to the inner map, compatible with
-    /// [`PhysicalModel::set_injections`].
+    /// [`PhysicalModel::set_injections`](crate::physics::PhysicalModel::set_injections).
     pub fn as_map(&self) -> &HashMap<Option<String>, TemporalInjection> {
         &self.injections
     }

--- a/src/domain/sample.rs
+++ b/src/domain/sample.rs
@@ -1,20 +1,20 @@
-//! Échantillon — injection profiles at the column inlet.
+//! Inlet injection profiles — sample description at the column inlet.
 //!
-//! Ce module définit [`Sample`], le type qui regroupe les profils d'injection
-//! temporelle à l'entrée de la colonne ($z = 0$) pour une ou plusieurs espèces.
+//! This module defines [`Sample`], which groups the temporal injection profiles
+//! at the column inlet ($z = 0$) for one or more species.
 //!
 //! # Design
 //!
-//! `Sample` utilise le même schéma clé/valeur que [`PhysicalModel::set_injections`] :
+//! `Sample` uses the same key/value scheme as [`PhysicalModel::set_injections`]:
 //!
-//! | Clé | Signification |
-//! |-----|--------------|
-//! | `None` | Profil par défaut — appliqué à toutes les espèces sans override |
-//! | `Some(name)` | Override par espèce nommée |
+//! | Key | Meaning |
+//! |-----|---------|
+//! | `None` | Default profile — applied to all species without a per-species override |
+//! | `Some(name)` | Per-species override for the named species |
 //!
-//! Ce schéma est identique à celui de [`HashMap<Option<String>, TemporalInjection>`]
-//! déjà utilisé dans `LangmuirSingle` et `LangmuirMulti`, et s'intègre
-//! directement avec [`PhysicalModel::set_injections`].
+//! This scheme is identical to the `HashMap<Option<String>, TemporalInjection>`
+//! already used inside `LangmuirSingle` and `LangmuirMulti`, and integrates
+//! directly with [`PhysicalModel::set_injections`].
 //!
 //! # Example
 //!
@@ -22,10 +22,10 @@
 //! use chrom_rs::domain::Sample;
 //! use chrom_rs::models::TemporalInjection;
 //!
-//! // Injection gaussienne pour toutes les espèces
+//! // Single Gaussian profile applied to all species
 //! let sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
 //!
-//! // Override par espèce
+//! // Per-species override
 //! let mut sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
 //! sample.set_species("B", TemporalInjection::rectangle(5.0, 15.0, 0.05));
 //! ```
@@ -38,11 +38,11 @@ use std::collections::HashMap;
 // Sample
 // =============================================================================
 
-/// Profils d'injection à l'entrée de la colonne — inlet injection profiles.
+/// Inlet injection profiles for a chromatographic run.
 ///
-/// Regroupe les [`TemporalInjection`] pour une ou plusieurs espèces.
-/// La clé `None` définit le profil par défaut (toutes les espèces) ;
-/// `Some(name)` surcharge le profil pour une espèce nommée.
+/// Groups [`TemporalInjection`] profiles for one or more species.
+/// The `None` key defines the default profile (all species);
+/// `Some(name)` overrides the profile for a named species.
 ///
 /// # Example
 ///
@@ -50,16 +50,17 @@ use std::collections::HashMap;
 /// use chrom_rs::domain::Sample;
 /// use chrom_rs::models::TemporalInjection;
 ///
-/// // Profil unique pour toutes les espèces
+/// // Single profile for all species
 /// let sample = Sample::uniform(TemporalInjection::dirac(5.0, 0.1));
 /// assert!(sample.default_injection().is_some());
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Sample {
-    /// Profils d'injection indexés par espèce — injection profiles indexed by species.
+    /// Injection profiles indexed by species.
     ///
-    /// - `None`      → profil par défaut pour toutes les espèces
-    /// - `Some(s)`   → override pour l'espèce nommée `s`
+    /// Profils d'injection indexés par espèce :
+    /// - `None`    → profil par défaut pour toutes les espèces
+    /// - `Some(s)` → override pour l'espèce nommée `s`
     pub injections: HashMap<Option<String>, TemporalInjection>,
 }
 
@@ -68,7 +69,7 @@ impl Sample {
     // Constructors
     // =========================================================================
 
-    /// Crée un `Sample` vide — creates an empty sample.
+    /// Creates an empty sample with no injection profiles.
     ///
     /// # Example
     ///
@@ -84,8 +85,6 @@ impl Sample {
         }
     }
 
-    /// Crée un `Sample` avec un profil unique pour toutes les espèces.
-    ///
     /// Creates a sample with a single default injection profile applied to
     /// all species (key `None`).
     ///
@@ -108,15 +107,11 @@ impl Sample {
     // Accessors and mutators
     // =========================================================================
 
-    /// Définit ou remplace le profil par défaut (toutes les espèces).
-    ///
     /// Sets or replaces the default injection profile (all species).
     pub fn set_default(&mut self, injection: TemporalInjection) {
         self.injections.insert(None, injection);
     }
 
-    /// Définit ou remplace le profil d'une espèce nommée.
-    ///
     /// Sets or replaces the injection profile for a named species.
     ///
     /// # Example
@@ -133,30 +128,21 @@ impl Sample {
         self.injections.insert(Some(name.to_string()), injection);
     }
 
-    /// Retourne le profil par défaut, s'il existe.
-    ///
     /// Returns the default injection profile, if any.
     pub fn default_injection(&self) -> Option<&TemporalInjection> {
         self.injections.get(&None)
     }
 
-    /// Retourne le profil d'une espèce nommée, s'il existe.
-    ///
     /// Returns the injection profile for a named species, if any.
     pub fn species_injection(&self, name: &str) -> Option<&TemporalInjection> {
         self.injections.get(&Some(name.to_string()))
     }
 
-    /// Retourne `true` si aucun profil n'est défini.
-    ///
     /// Returns `true` if no injection profile is defined.
     pub fn is_empty(&self) -> bool {
         self.injections.is_empty()
     }
 
-    /// Retourne une référence à la map interne, compatible avec
-    /// [`PhysicalModel::set_injections`].
-    ///
     /// Returns a reference to the inner map, compatible with
     /// [`PhysicalModel::set_injections`].
     pub fn as_map(&self) -> &HashMap<Option<String>, TemporalInjection> {

--- a/src/domain/sample.rs
+++ b/src/domain/sample.rs
@@ -1,0 +1,214 @@
+//! Échantillon — injection profiles at the column inlet.
+//!
+//! Ce module définit [`Sample`], le type qui regroupe les profils d'injection
+//! temporelle à l'entrée de la colonne ($z = 0$) pour une ou plusieurs espèces.
+//!
+//! # Design
+//!
+//! `Sample` utilise le même schéma clé/valeur que [`PhysicalModel::set_injections`] :
+//!
+//! | Clé | Signification |
+//! |-----|--------------|
+//! | `None` | Profil par défaut — appliqué à toutes les espèces sans override |
+//! | `Some(name)` | Override par espèce nommée |
+//!
+//! Ce schéma est identique à celui de [`HashMap<Option<String>, TemporalInjection>`]
+//! déjà utilisé dans `LangmuirSingle` et `LangmuirMulti`, et s'intègre
+//! directement avec [`PhysicalModel::set_injections`].
+//!
+//! # Example
+//!
+//! ```rust
+//! use chrom_rs::domain::Sample;
+//! use chrom_rs::models::TemporalInjection;
+//!
+//! // Injection gaussienne pour toutes les espèces
+//! let sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+//!
+//! // Override par espèce
+//! let mut sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+//! sample.set_species("B", TemporalInjection::rectangle(5.0, 15.0, 0.05));
+//! ```
+
+use crate::models::TemporalInjection;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+// =============================================================================
+// Sample
+// =============================================================================
+
+/// Profils d'injection à l'entrée de la colonne — inlet injection profiles.
+///
+/// Regroupe les [`TemporalInjection`] pour une ou plusieurs espèces.
+/// La clé `None` définit le profil par défaut (toutes les espèces) ;
+/// `Some(name)` surcharge le profil pour une espèce nommée.
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::domain::Sample;
+/// use chrom_rs::models::TemporalInjection;
+///
+/// // Profil unique pour toutes les espèces
+/// let sample = Sample::uniform(TemporalInjection::dirac(5.0, 0.1));
+/// assert!(sample.default_injection().is_some());
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Sample {
+    /// Profils d'injection indexés par espèce — injection profiles indexed by species.
+    ///
+    /// - `None`      → profil par défaut pour toutes les espèces
+    /// - `Some(s)`   → override pour l'espèce nommée `s`
+    pub injections: HashMap<Option<String>, TemporalInjection>,
+}
+
+impl Sample {
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+
+    /// Crée un `Sample` vide — creates an empty sample.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::Sample;
+    ///
+    /// let sample = Sample::empty();
+    /// assert!(sample.is_empty());
+    /// ```
+    pub fn empty() -> Self {
+        Self {
+            injections: HashMap::new(),
+        }
+    }
+
+    /// Crée un `Sample` avec un profil unique pour toutes les espèces.
+    ///
+    /// Creates a sample with a single default injection profile applied to
+    /// all species (key `None`).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::Sample;
+    /// use chrom_rs::models::TemporalInjection;
+    ///
+    /// let sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+    /// assert!(sample.default_injection().is_some());
+    /// ```
+    pub fn uniform(injection: TemporalInjection) -> Self {
+        let mut injections = HashMap::new();
+        injections.insert(None, injection);
+        Self { injections }
+    }
+
+    // =========================================================================
+    // Accessors and mutators
+    // =========================================================================
+
+    /// Définit ou remplace le profil par défaut (toutes les espèces).
+    ///
+    /// Sets or replaces the default injection profile (all species).
+    pub fn set_default(&mut self, injection: TemporalInjection) {
+        self.injections.insert(None, injection);
+    }
+
+    /// Définit ou remplace le profil d'une espèce nommée.
+    ///
+    /// Sets or replaces the injection profile for a named species.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::Sample;
+    /// use chrom_rs::models::TemporalInjection;
+    ///
+    /// let mut sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+    /// sample.set_species("B", TemporalInjection::rectangle(5.0, 15.0, 0.05));
+    /// assert!(sample.species_injection("B").is_some());
+    /// ```
+    pub fn set_species(&mut self, name: &str, injection: TemporalInjection) {
+        self.injections.insert(Some(name.to_string()), injection);
+    }
+
+    /// Retourne le profil par défaut, s'il existe.
+    ///
+    /// Returns the default injection profile, if any.
+    pub fn default_injection(&self) -> Option<&TemporalInjection> {
+        self.injections.get(&None)
+    }
+
+    /// Retourne le profil d'une espèce nommée, s'il existe.
+    ///
+    /// Returns the injection profile for a named species, if any.
+    pub fn species_injection(&self, name: &str) -> Option<&TemporalInjection> {
+        self.injections.get(&Some(name.to_string()))
+    }
+
+    /// Retourne `true` si aucun profil n'est défini.
+    ///
+    /// Returns `true` if no injection profile is defined.
+    pub fn is_empty(&self) -> bool {
+        self.injections.is_empty()
+    }
+
+    /// Retourne une référence à la map interne, compatible avec
+    /// [`PhysicalModel::set_injections`].
+    ///
+    /// Returns a reference to the inner map, compatible with
+    /// [`PhysicalModel::set_injections`].
+    pub fn as_map(&self) -> &HashMap<Option<String>, TemporalInjection> {
+        &self.injections
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sample_empty() {
+        let sample = Sample::empty();
+        assert!(sample.is_empty());
+        assert!(sample.default_injection().is_none());
+    }
+
+    #[test]
+    fn test_sample_uniform() {
+        let sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+        assert!(!sample.is_empty());
+        assert!(sample.default_injection().is_some());
+    }
+
+    #[test]
+    fn test_sample_set_default() {
+        let mut sample = Sample::empty();
+        sample.set_default(TemporalInjection::dirac(5.0, 0.1));
+        assert!(sample.default_injection().is_some());
+    }
+
+    #[test]
+    fn test_sample_set_species() {
+        let mut sample = Sample::uniform(TemporalInjection::gaussian(10.0, 2.0, 0.1));
+        sample.set_species("B", TemporalInjection::rectangle(5.0, 15.0, 0.05));
+        assert!(sample.species_injection("B").is_some());
+        assert!(sample.species_injection("A").is_none());
+    }
+
+    #[test]
+    fn test_sample_as_map_compatible_with_set_injections() {
+        let mut sample = Sample::uniform(TemporalInjection::dirac(5.0, 0.1));
+        sample.set_species("Malic", TemporalInjection::gaussian(10.0, 2.0, 0.05));
+
+        let map = sample.as_map();
+        assert!(map.contains_key(&None));
+        assert!(map.contains_key(&Some("Malic".to_string())));
+        assert_eq!(map.len(), 2);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,18 @@
 //! | [`cli`] | Command-line interface built on `dynamic-cli` |
 //! | [`prelude`] | Convenience re-exports for the most common types |
 
+/// Physical domain model — equipment description layer.
+///
+/// Provides validated, model-agnostic types for the physical equipment:
+/// [`domain::Column`], [`domain::MobilePhase`], [`domain::Sample`], and
+/// [`domain::Detector`]. These types serve as a construction facade for all
+/// physical models ([`models::LangmuirSingle`], [`models::LangmuirMulti`], …)
+/// via their `from_domain` constructors.
+///
+/// See [DD-011](https://github.com/biface/chromatography/issues/16) for the
+/// design rationale.
+pub mod domain;
+
 /// Physical model traits, state containers, and data types.
 ///
 /// Defines the extension points that all physical models must implement,
@@ -125,6 +137,9 @@ pub mod cli;
 /// use chrom_rs::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::domain::{
+        Column, ColumnError, Detector, DetectorPosition, MobilePhase, MobilePhaseError, Sample,
+    };
     pub use crate::models::TemporalInjection;
     pub use crate::physics::{PhysicalData, PhysicalModel, PhysicalQuantity, PhysicalState};
     pub use crate::solver::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(nalgebra::DVector::from_vec(vec![1.0])))
 //! #     }

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -976,10 +976,10 @@ impl Exportable for LangmuirMulti {
         let mut meta: Map<String, Value> = [
             ("model", Value::String(self.name().into())),
             ("n_species", Value::from(self.n_species() as u64)),
-            ("nz", Value::from(self.spatial_points() as u64)),
+            ("n_points", Value::from(self.spatial_points() as u64)),
             ("porosity", Value::from(self.porosity())),
             ("velocity", Value::from(self.velocity())),
-            ("length", Value::from(self.column_length())),
+            ("column_length", Value::from(self.column_length())),
             ("species", Value::Array(species_meta)),
         ]
         .into_iter()
@@ -1041,10 +1041,10 @@ impl Exportable for LangmuirMulti {
     ///
     /// | Key | Type | Description |
     /// |---|---|---|
-    /// | `nz` | `u64` | Number of spatial points |
+    /// | `n_points` | `u64` | Number of spatial points |
     /// | `porosity` | `f64` | Extra-granular porosity ε ∈ (0, 1) |
     /// | `velocity` | `f64` | Superficial velocity (m/s) |
-    /// | `length` | `f64` | Column length (m) |
+    /// | `column_length` | `f64` | Column length (m) |
     /// | `species` | array | Per-species parameters (see below) |
     ///
     /// Each entry in `metadata.species` must contain:
@@ -1085,10 +1085,10 @@ impl Exportable for LangmuirMulti {
             };
         }
 
-        let nz = get_usize!("nz");
+        let n_points = get_usize!("n_points");
         let porosity = get_f64!("porosity");
         let velocity = get_f64!("velocity");
-        let length = get_f64!("length");
+        let column_length = get_f64!("column_length");
 
         let species_arr = meta
             .get("species")
@@ -1144,12 +1144,12 @@ impl Exportable for LangmuirMulti {
 
         let first = params.remove(0);
         let mut model =
-            LangmuirMulti::new(vec![first], nz, porosity, velocity, length).map_err(|e| {
-                ExportError::InvalidValue {
+            LangmuirMulti::new(vec![first], n_points, porosity, velocity, column_length).map_err(
+                |e| ExportError::InvalidValue {
                     key: "metadata".into(),
                     reason: e,
-                }
-            })?;
+                },
+            )?;
 
         for sp in params {
             model
@@ -1753,7 +1753,7 @@ mod tests {
         use serde_json::json;
         let map = json!({
             "metadata": {
-                "nz": 100, "porosity": 0.4, "velocity": 0.001, "length": 0.25,
+                "n_points": 100, "porosity": 0.4, "velocity": 0.001, "column_length": 0.25,
                 "species": []
             }
         })
@@ -1777,7 +1777,7 @@ mod tests {
         // "porosity" absent — all other required keys present
         let map = json!({
             "metadata": {
-                "nz": 100, "velocity": 0.001, "length": 0.25,
+                "n_points": 100, "velocity": 0.001, "column_length": 0.25,
                 "species": [{"name": "A", "lambda": 1.0, "langmuir_k": 0.5, "port_number": 1}]
             }
         })

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -409,6 +409,55 @@ impl LangmuirMulti {
         })
     }
 
+    /// Creates a `LangmuirMulti` model from validated domain objects.
+    ///
+    /// Accepts a [`Column`](crate::domain::Column) and a
+    /// [`MobilePhase`](crate::domain::MobilePhase) as construction input,
+    /// delegating to [`new`](Self::new) after extracting the required fields.
+    ///
+    /// # Arguments
+    ///
+    /// * `column`       - validated column geometry
+    /// * `mobile_phase` - validated mobile-phase properties
+    /// * `species`      - list of [`SpeciesParams`] (at least one, no duplicates)
+    ///
+    /// # Errors
+    ///
+    /// Propagates any error from [`new`](Self::new): empty species list,
+    /// duplicate species names, or invalid species parameters.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Column, MobilePhase};
+    /// use chrom_rs::models::{LangmuirMulti, SpeciesParams};
+    /// use chrom_rs::models::injection::TemporalInjection;
+    ///
+    /// let column = Column::new(0.25, 100, 0.4, None).unwrap();
+    /// let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+    /// let species = vec![
+    ///     SpeciesParams::new("A", 1.2, 0.4, 2, TemporalInjection::none()),
+    /// ];
+    ///
+    /// let model = LangmuirMulti::from_domain(&column, &mobile_phase, species).unwrap();
+    ///
+    /// assert_eq!(model.n_species(), 1);
+    /// assert!((model.column_length() - 0.25).abs() < 1e-12);
+    /// ```
+    pub fn from_domain(
+        column: &crate::domain::Column,
+        mobile_phase: &crate::domain::MobilePhase,
+        species: Vec<SpeciesParams>,
+    ) -> Result<Self, String> {
+        Self::new(
+            species,
+            column.n_points,
+            column.porosity,
+            mobile_phase.velocity,
+            column.column_length,
+        )
+    }
+
     /// Adds a competing chemical species to the model
     ///
     /// # Errors
@@ -424,10 +473,6 @@ impl LangmuirMulti {
     /// let inj = TemporalInjection::dirac(0.0, 1e-3);
     /// let sp1 = SpeciesParams::new("A", 1.0, 0.5, 1, inj.clone());
     /// let sp2 = SpeciesParams::new("B", 1.0, 2.0, 1, inj);
-    ///
-    /// let mut model = LangmuirMulti::new(vec![sp1], 50, 0.4, 0.001, 0.25).unwrap();
-    /// model.add_species(sp2).unwrap();
-    /// assert_eq!(model.n_species(), 2);
     /// ```
     pub fn add_species(&mut self, species: SpeciesParams) -> Result<(), String> {
         // validate the specie
@@ -1797,5 +1842,65 @@ mod tests {
             ),
             "Missing 'porosity' must yield MissingKey"
         );
+    }
+
+    #[test]
+    fn test_from_domain_builds_equivalent_model() {
+        use crate::domain::{Column, MobilePhase};
+
+        let column = Column::new(0.25, 100, 0.4, None).unwrap();
+        let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+        let species = vec![SpeciesParams::new(
+            "A",
+            1.2,
+            0.4,
+            2,
+            TemporalInjection::none(),
+        )];
+
+        let model = LangmuirMulti::from_domain(&column, &mobile_phase, species).unwrap();
+
+        assert_eq!(model.n_species(), 1);
+        assert!((model.column_length() - 0.25).abs() < 1e-12);
+        assert_eq!(model.spatial_points(), 100);
+    }
+
+    #[test]
+    fn test_from_domain_multi_species() {
+        use crate::domain::{Column, MobilePhase};
+
+        let column = Column::new(0.25, 100, 0.4, None).unwrap();
+        let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+        let species = vec![
+            SpeciesParams::new("A", 1.2, 0.4, 2, TemporalInjection::none()),
+            SpeciesParams::new("B", 0.8, 0.3, 2, TemporalInjection::none()),
+        ];
+
+        let model = LangmuirMulti::from_domain(&column, &mobile_phase, species).unwrap();
+        assert_eq!(model.n_species(), 2);
+    }
+
+    #[test]
+    fn test_from_domain_empty_species_fails() {
+        use crate::domain::{Column, MobilePhase};
+
+        let column = Column::new(0.25, 100, 0.4, None).unwrap();
+        let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+
+        assert!(LangmuirMulti::from_domain(&column, &mobile_phase, vec![]).is_err());
+    }
+
+    #[test]
+    fn test_from_domain_duplicate_species_fails() {
+        use crate::domain::{Column, MobilePhase};
+
+        let column = Column::new(0.25, 100, 0.4, None).unwrap();
+        let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+        let species = vec![
+            SpeciesParams::new("A", 1.2, 0.4, 2, TemporalInjection::none()),
+            SpeciesParams::new("A", 0.8, 0.3, 2, TemporalInjection::none()),
+        ];
+
+        assert!(LangmuirMulti::from_domain(&column, &mobile_phase, species).is_err());
     }
 }

--- a/src/models/langmuir_multi.rs
+++ b/src/models/langmuir_multi.rs
@@ -669,16 +669,19 @@ impl PhysicalModel for LangmuirMulti {
     ///
     /// **Singular matrix fallback**: identity matrix + warning log. The solver will
     /// catch any NaN/Inf in the resulting state.
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        ctx: &crate::physics::context::ComputeContext,
+    ) -> PhysicalState {
         let n_species = self.n_species();
 
         // ── Time ──────────────────────────────────────────────────────────────────
         //
-        // The solver writes the current simulation time into the state metadata
-        // before each call. If absent (e.g. first call, or solver does not support
-        // metadata), we default to t=0.0 — injection profiles will return their
-        // value at t=0.
-        let t = state.get_metadata("time").unwrap_or(0.0);
+        // The solver passes the current simulation time via ComputeContext.
+        // Infallible — no unwrap_or required. Replaces the previous convention
+        // of reading state.get_metadata("time") (DD-008).
+        let t = ctx.time();
 
         // ── State extraction ──────────────────────────────────────────────────────
         //
@@ -976,10 +979,10 @@ impl Exportable for LangmuirMulti {
         let mut meta: Map<String, Value> = [
             ("model", Value::String(self.name().into())),
             ("n_species", Value::from(self.n_species() as u64)),
-            ("n_points", Value::from(self.spatial_points() as u64)),
+            ("nz", Value::from(self.spatial_points() as u64)),
             ("porosity", Value::from(self.porosity())),
             ("velocity", Value::from(self.velocity())),
-            ("column_length", Value::from(self.column_length())),
+            ("length", Value::from(self.column_length())),
             ("species", Value::Array(species_meta)),
         ]
         .into_iter()
@@ -1041,10 +1044,10 @@ impl Exportable for LangmuirMulti {
     ///
     /// | Key | Type | Description |
     /// |---|---|---|
-    /// | `n_points` | `u64` | Number of spatial points |
+    /// | `nz` | `u64` | Number of spatial points |
     /// | `porosity` | `f64` | Extra-granular porosity ε ∈ (0, 1) |
     /// | `velocity` | `f64` | Superficial velocity (m/s) |
-    /// | `column_length` | `f64` | Column length (m) |
+    /// | `length` | `f64` | Column length (m) |
     /// | `species` | array | Per-species parameters (see below) |
     ///
     /// Each entry in `metadata.species` must contain:
@@ -1085,10 +1088,10 @@ impl Exportable for LangmuirMulti {
             };
         }
 
-        let n_points = get_usize!("n_points");
+        let nz = get_usize!("nz");
         let porosity = get_f64!("porosity");
         let velocity = get_f64!("velocity");
-        let column_length = get_f64!("column_length");
+        let length = get_f64!("length");
 
         let species_arr = meta
             .get("species")
@@ -1144,12 +1147,12 @@ impl Exportable for LangmuirMulti {
 
         let first = params.remove(0);
         let mut model =
-            LangmuirMulti::new(vec![first], n_points, porosity, velocity, column_length).map_err(
-                |e| ExportError::InvalidValue {
+            LangmuirMulti::new(vec![first], nz, porosity, velocity, length).map_err(|e| {
+                ExportError::InvalidValue {
                     key: "metadata".into(),
                     reason: e,
-                },
-            )?;
+                }
+            })?;
 
         for sp in params {
             model
@@ -1440,7 +1443,8 @@ mod tests {
     #[test]
     fn test_compute_physics_output_shape() {
         let model = two_species_model();
-        let phys = model.compute_physics(&model.setup_initial_state());
+        let ctx = crate::physics::ComputeContext::new(0.0, 0.0);
+        let phys = model.compute_physics(&model.setup_initial_state(), &ctx);
         let mat = phys
             .get(PhysicalQuantity::Concentration)
             .unwrap()
@@ -1475,19 +1479,19 @@ mod tests {
             ))
             .unwrap();
 
-        let mut state = model.setup_initial_state();
+        let state = model.setup_initial_state();
 
-        state.set_metadata("time".to_string(), 0.0);
+        let ctx_0 = crate::physics::ComputeContext::new(0.0, 0.0);
         let dc_t0 = model
-            .compute_physics(&state)
+            .compute_physics(&state, &ctx_0)
             .get(PhysicalQuantity::Concentration)
             .unwrap()
             .as_matrix()
             .clone_owned();
 
-        state.set_metadata("time".to_string(), 10.0);
+        let ctx_10 = crate::physics::ComputeContext::new(10.0, 0.0);
         let dc_t10 = model
-            .compute_physics(&state)
+            .compute_physics(&state, &ctx_10)
             .get(PhysicalQuantity::Concentration)
             .unwrap()
             .as_matrix()
@@ -1507,8 +1511,9 @@ mod tests {
     fn test_compute_physics_defaults_to_t0_without_metadata() {
         // Without metadata the model must not panic — defaults to t=0.0
         let model = two_species_model();
+        let ctx = crate::physics::ComputeContext::new(0.0, 0.0);
         let mat = model
-            .compute_physics(&model.setup_initial_state())
+            .compute_physics(&model.setup_initial_state(), &ctx)
             .get(PhysicalQuantity::Concentration)
             .unwrap()
             .as_matrix()
@@ -1522,10 +1527,10 @@ mod tests {
     #[test]
     fn test_compute_physics_no_nan_or_inf() {
         let model = two_species_model();
-        let mut st = model.setup_initial_state();
-        st.set_metadata("time".to_string(), 5.0);
+        let st = model.setup_initial_state();
+        let ctx = crate::physics::ComputeContext::new(5.0, 0.0);
         let mat = model
-            .compute_physics(&st)
+            .compute_physics(&st, &ctx)
             .get(PhysicalQuantity::Concentration)
             .unwrap()
             .as_matrix()
@@ -1541,10 +1546,10 @@ mod tests {
         // On an empty column, interior points (i>0) have zero gradient → dC/dt = 0.
         // Row 0 may be non-zero if injection.evaluate(t) > 0 (Dirac at t=0).
         let model = two_species_model();
-        let mut st = model.setup_initial_state();
-        st.set_metadata("time".to_string(), 0.0);
+        let st = model.setup_initial_state();
+        let ctx = crate::physics::ComputeContext::new(0.0, 0.0);
         let mat = model
-            .compute_physics(&st)
+            .compute_physics(&st, &ctx)
             .get(PhysicalQuantity::Concentration)
             .unwrap()
             .as_matrix()
@@ -1753,7 +1758,7 @@ mod tests {
         use serde_json::json;
         let map = json!({
             "metadata": {
-                "n_points": 100, "porosity": 0.4, "velocity": 0.001, "column_length": 0.25,
+                "nz": 100, "porosity": 0.4, "velocity": 0.001, "length": 0.25,
                 "species": []
             }
         })
@@ -1777,7 +1782,7 @@ mod tests {
         // "porosity" absent — all other required keys present
         let map = json!({
             "metadata": {
-                "n_points": 100, "velocity": 0.001, "column_length": 0.25,
+                "nz": 100, "velocity": 0.001, "length": 0.25,
                 "species": [{"name": "A", "lambda": 1.0, "langmuir_k": 0.5, "port_number": 1}]
             }
         })

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -147,7 +147,7 @@ use std::collections::HashMap;
 ///     1.2, 0.4, 2.0, 0.4, 0.001, 0.25, 100,
 ///     TemporalInjection::dirac(0.0, 1e-3),
 /// );
-/// assert_eq!(model.length(), 0.25);
+/// assert_eq!(model.column_length(), 0.25);
 /// assert_eq!(model.spatial_points(), 100);
 /// ```
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -174,10 +174,10 @@ pub struct LangmuirSingle {
 
     // ── Column geometry ───────────────────────────────────────────────────────
     /// Column length $L$ **\[m\]**
-    length: f64,
+    column_length: f64,
 
     /// Number of spatial discretization points $N_z$
-    nz: usize,
+    n_points: usize,
 
     /// Cell width $\Delta z = L / N_z$ **\[m\]** — precomputed
     ///
@@ -266,8 +266,8 @@ impl LangmuirSingle {
             lambda,
             langmuir_k,
             port_number,
-            length: column_length,
-            nz: spatial_points,
+            column_length,
+            n_points: spatial_points,
             dz,
             fe,
             ue,
@@ -302,12 +302,12 @@ impl LangmuirSingle {
 
     /// Returns the number of spatial discretization points $N_z$
     pub fn spatial_points(&self) -> usize {
-        self.nz
+        self.n_points
     }
 
     /// Returns the column length $L$ **\[m\]**
-    pub fn length(&self) -> f64 {
-        self.length
+    pub fn column_length(&self) -> f64 {
+        self.column_length
     }
 
     /// Computes the isotherm derivative $\partial \bar{C} / \partial C$
@@ -354,7 +354,7 @@ impl LangmuirSingle {
 impl PhysicalModel for LangmuirSingle {
     /// Returns the number of spatial discretisation points $N_z$
     fn points(&self) -> usize {
-        self.nz
+        self.n_points
     }
 
     /// Computes $\partial C / \partial t$ at all spatial points
@@ -406,10 +406,10 @@ impl PhysicalModel for LangmuirSingle {
 
         assert_eq!(
             c_profile.len(),
-            self.nz,
+            self.n_points,
             "Concentration profile size {} vs points discretization {}",
             c_profile.len(),
-            self.nz
+            self.n_points
         );
 
         // ── Transport loop ────────────────────────────────────────────────────
@@ -418,9 +418,9 @@ impl PhysicalModel for LangmuirSingle {
         // The propagation factor σ(C_i) depends on the local concentration,
         // making this a nonlinear PDE — hence the point-by-point evaluation.
 
-        let mut dc_dt = DVector::zeros(self.nz);
+        let mut dc_dt = DVector::zeros(self.n_points);
 
-        for n in 0..self.nz {
+        for n in 0..self.n_points {
             let c_n = c_profile[n];
 
             // Propagation factor: σ(C) = 1 / (1 + Fe · ∂C̄/∂C)
@@ -452,7 +452,7 @@ impl PhysicalModel for LangmuirSingle {
     fn setup_initial_state(&self) -> PhysicalState {
         PhysicalState::new(
             PhysicalQuantity::Concentration,
-            PhysicalData::Vector(DVector::zeros(self.nz)),
+            PhysicalData::Vector(DVector::zeros(self.n_points)),
         )
     }
 
@@ -489,16 +489,16 @@ impl Exportable for LangmuirSingle {
     /// ```json
     /// {
     ///   "metadata": {
-    ///     "model":       "Langmuir single specie with temporal injection",
-    ///     "lambda":      1.2,
-    ///     "langmuir_k":  0.4,
-    ///     "port_number": 2.0,
-    ///     "length":      0.25,
-    ///     "nz":          100,
-    ///     "fe":          1.5,
-    ///     "ue":          0.0025,
-    ///     "solver":      "Runge-Kutta 4",
-    ///     "dt":          "0.06"
+    ///     "model":              "Langmuir single specie with temporal injection",
+    ///     "lambda":             1.2,
+    ///     "langmuir_k":         0.4,
+    ///     "port_number":        2.0,
+    ///     "columns_length":     0.25,
+    ///     "n_points":           100,
+    ///     "fe":                 1.5,
+    ///     "ue":                 0.0025,
+    ///     "solver":             "Runge-Kutta 4",
+    ///     "dt":                 "0.06"
     ///   },
     ///   "data": {
     ///     "time_points": [0.0, 0.06, "..."],
@@ -528,8 +528,8 @@ impl Exportable for LangmuirSingle {
             ("lambda", Value::from(self.lambda)),
             ("langmuir_k", Value::from(self.langmuir_k)),
             ("port_number", Value::from(self.port_number)),
-            ("length", Value::from(self.length)),
-            ("nz", Value::from(self.nz as u64)),
+            ("column_length", Value::from(self.column_length)),
+            ("n_points", Value::from(self.n_points as u64)),
             ("fe", Value::from(self.fe)),
             ("ue", Value::from(self.ue)),
         ]
@@ -583,8 +583,8 @@ impl Exportable for LangmuirSingle {
     /// | `lambda` | `f64` | Linear retention term |
     /// | `langmuir_k` | `f64` | Langmuir equilibrium constant |
     /// | `port_number` | `f64` | Adsorption capacity |
-    /// | `length` | `f64` | Column length (m) |
-    /// | `nz` | `u64` | Number of spatial points |
+    /// | `column_length` | `f64` | Column length (m) |
+    /// | `n_points` | `u64` | Number of spatial points |
     /// | `fe` | `f64` | Phase ratio — back-computes porosity as `1 / (1 + fe)` |
     /// | `ue` | `f64` | Interstitial velocity — back-computes velocity as `ue × ε` |
     ///
@@ -623,10 +623,10 @@ impl Exportable for LangmuirSingle {
         let lambda = get_f64!("lambda");
         let langmuir_k = get_f64!("langmuir_k");
         let port_number = get_f64!("port_number");
-        let length = get_f64!("length");
+        let length = get_f64!("column_length");
         let fe = get_f64!("fe");
         let ue = get_f64!("ue");
-        let nz = get_usize!("nz");
+        let nz = get_usize!("n_points");
 
         // Back-compute constructor arguments from derived quantities:
         //   fe = (1 - ε) / ε  →  ε = 1 / (1 + fe)
@@ -815,7 +815,7 @@ mod tests {
 
         // Physical parameters must be unchanged after set_injection
         assert_eq!(model.spatial_points(), 100);
-        assert!((model.length() - 0.25).abs() < 1e-15);
+        assert!((model.column_length() - 0.25).abs() < 1e-15);
     }
 
     // ── Exportable ────────────────────────────────────────────────────────────
@@ -841,8 +841,8 @@ mod tests {
             "lambda",
             "langmuir_k",
             "port_number",
-            "length",
-            "nz",
+            "column_length",
+            "n_points",
             "fe",
             "ue",
         ] {
@@ -850,7 +850,7 @@ mod tests {
         }
         assert!((meta["lambda"].as_f64().unwrap() - 1.2).abs() < 1e-12);
         assert!((meta["langmuir_k"].as_f64().unwrap() - 0.4).abs() < 1e-12);
-        assert_eq!(meta["nz"].as_u64().unwrap(), 100);
+        assert_eq!(meta["n_points"].as_u64().unwrap(), 100);
     }
 
     #[test]
@@ -913,7 +913,7 @@ mod tests {
         let reconstructed = LangmuirSingle::from_map(map).expect("from_map must succeed");
 
         assert_eq!(reconstructed.spatial_points(), original.spatial_points());
-        assert!((reconstructed.length() - original.length()).abs() < 1e-12);
+        assert!((reconstructed.column_length() - original.column_length()).abs() < 1e-12);
 
         // Second pass: derived quantities (fe, ue) must survive the back-computation
         // porosity = 1/(1+fe), velocity = ue × ε
@@ -937,7 +937,7 @@ mod tests {
         assert!(
             matches!(
                 LangmuirSingle::from_map(partial),
-                Err(ExportError::MissingKey(_))
+                Err(ExportError::MissingKey(key)) if key == "lambda"
             ),
             "Missing 'lambda' must yield MissingKey"
         );

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -376,14 +376,18 @@ impl PhysicalModel for LangmuirSingle {
     ///
     /// **Interior and right boundary** ($i > 0$): standard backward difference
     /// using the real upstream neighbor $C_{i-1}$.
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        ctx: &crate::physics::context::ComputeContext,
+    ) -> PhysicalState {
         // ── Time ──────────────────────────────────────────────────────────────
         //
-        // The solver writes the current simulation time into the state metadata
-        // before each call. If absent (e.g. solver does not support metadata),
-        // defaults to t=0.0 — injection profiles return their value at t=0.
+        // The solver passes the current simulation time via ComputeContext.
+        // Infallible — no unwrap_or required. Replaces the previous convention
+        // of reading state.get_metadata("time") (DD-008).
 
-        let t = state.get_metadata("time").unwrap_or(0.0);
+        let t = ctx.time();
 
         // ── Inlet concentration ───────────────────────────────────────────────
         //
@@ -489,16 +493,16 @@ impl Exportable for LangmuirSingle {
     /// ```json
     /// {
     ///   "metadata": {
-    ///     "model":              "Langmuir single specie with temporal injection",
-    ///     "lambda":             1.2,
-    ///     "langmuir_k":         0.4,
-    ///     "port_number":        2.0,
-    ///     "columns_length":     0.25,
-    ///     "n_points":           100,
-    ///     "fe":                 1.5,
-    ///     "ue":                 0.0025,
-    ///     "solver":             "Runge-Kutta 4",
-    ///     "dt":                 "0.06"
+    ///     "model":       "Langmuir single specie with temporal injection",
+    ///     "lambda":      1.2,
+    ///     "langmuir_k":  0.4,
+    ///     "port_number": 2.0,
+    ///     "column_length":      0.25,
+    ///     "n_points":          100,
+    ///     "fe":          1.5,
+    ///     "ue":          0.0025,
+    ///     "solver":      "Runge-Kutta 4",
+    ///     "dt":          "0.06"
     ///   },
     ///   "data": {
     ///     "time_points": [0.0, 0.06, "..."],
@@ -583,8 +587,8 @@ impl Exportable for LangmuirSingle {
     /// | `lambda` | `f64` | Linear retention term |
     /// | `langmuir_k` | `f64` | Langmuir equilibrium constant |
     /// | `port_number` | `f64` | Adsorption capacity |
-    /// | `column_length` | `f64` | Column length (m) |
-    /// | `n_points` | `u64` | Number of spatial points |
+    /// | `length` | `f64` | Column length (m) |
+    /// | `nz` | `u64` | Number of spatial points |
     /// | `fe` | `f64` | Phase ratio — back-computes porosity as `1 / (1 + fe)` |
     /// | `ue` | `f64` | Interstitial velocity — back-computes velocity as `ue × ε` |
     ///
@@ -623,10 +627,10 @@ impl Exportable for LangmuirSingle {
         let lambda = get_f64!("lambda");
         let langmuir_k = get_f64!("langmuir_k");
         let port_number = get_f64!("port_number");
-        let length = get_f64!("column_length");
+        let column_length = get_f64!("column_length");
         let fe = get_f64!("fe");
         let ue = get_f64!("ue");
-        let nz = get_usize!("n_points");
+        let n_points = get_usize!("n_points");
 
         // Back-compute constructor arguments from derived quantities:
         //   fe = (1 - ε) / ε  →  ε = 1 / (1 + fe)
@@ -640,8 +644,8 @@ impl Exportable for LangmuirSingle {
             port_number,
             porosity,
             velocity,
-            length,
-            nz,
+            column_length,
+            n_points,
             TemporalInjection::none(),
         ))
     }
@@ -672,13 +676,13 @@ mod tests {
     #[test]
     fn test_read_time_from_metadata() {
         let model = create_langmuir_single();
-        let mut state = model.setup_initial_state();
+        let state = model.setup_initial_state();
 
         // Add time metadata (as if solver set it)
-        state.set_metadata("time".to_string(), 10.0);
+        let ctx = crate::physics::ComputeContext::new(10.0, 0.0);
 
         // Compute physics
-        let physics = model.compute_physics(&state);
+        let physics = model.compute_physics(&state, &ctx);
 
         // At t = 10.0, injection should be at peak (0.1 mol/L)
         // Should see effect at inlet
@@ -696,8 +700,8 @@ mod tests {
         let model = create_langmuir_single();
         let state = model.setup_initial_state();
 
-        // No metadata added - should default to t=0
-        let physics = model.compute_physics(&state);
+        let ctx = crate::physics::ComputeContext::new(0.0, 0.0);
+        let physics = model.compute_physics(&state, &ctx);
 
         // Should still work (uses t=0, so minimal injection)
         let dc_dt = physics
@@ -712,19 +716,19 @@ mod tests {
     #[test]
     fn test_different_times_different_physics() {
         let model = create_langmuir_single();
-        let mut state = model.setup_initial_state();
+        let state = model.setup_initial_state();
 
         // At t=0
-        state.set_metadata("time".to_string(), 0.0);
-        let physics_0 = model.compute_physics(&state);
+        let ctx_0 = crate::physics::ComputeContext::new(0.0, 0.0);
+        let physics_0 = model.compute_physics(&state, &ctx_0);
         let dc_dt_0 = physics_0
             .get(PhysicalQuantity::Concentration)
             .unwrap()
             .as_vector();
 
         // At t=10 (peak)
-        state.set_metadata("time".to_string(), 10.0);
-        let physics_10 = model.compute_physics(&state);
+        let ctx_10 = crate::physics::ComputeContext::new(10.0, 0.0);
+        let physics_10 = model.compute_physics(&state, &ctx_10);
         let dc_dt_10 = physics_10
             .get(PhysicalQuantity::Concentration)
             .unwrap()
@@ -937,7 +941,7 @@ mod tests {
         assert!(
             matches!(
                 LangmuirSingle::from_map(partial),
-                Err(ExportError::MissingKey(key)) if key == "lambda"
+                Err(ExportError::MissingKey(_))
             ),
             "Missing 'lambda' must yield MissingKey"
         );

--- a/src/models/langmuir_single.rs
+++ b/src/models/langmuir_single.rs
@@ -275,6 +275,64 @@ impl LangmuirSingle {
         }
     }
 
+    /// Creates a `LangmuirSingle` model from validated domain objects.
+    ///
+    /// Accepts a [`Column`](crate::domain::Column) and a
+    /// [`MobilePhase`](crate::domain::MobilePhase) as construction input,
+    /// delegating to [`new`](Self::new) after extracting the required fields.
+    ///
+    /// This is the preferred constructor when building a model from the domain
+    /// layer — it avoids passing raw `f64` parameters and benefits from the
+    /// validation already performed by `Column::new` and `MobilePhase::new`.
+    ///
+    /// # Arguments
+    ///
+    /// * `column`       — validated column geometry
+    /// * `mobile_phase` — validated mobile-phase properties
+    /// * `lambda`       — $\lambda \geq 0$ \[dimensionless\]
+    /// * `langmuir_k`   — $\tilde{K} > 0$ \[L/mol\]
+    /// * `port_number`  — $N > 0$ \[dimensionless\]
+    /// * `injection`    — temporal injection profile at $z = 0$
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::domain::{Column, MobilePhase};
+    /// use chrom_rs::models::{LangmuirSingle, TemporalInjection};
+    ///
+    /// let column = Column::new(0.25, 100, 0.4, None).unwrap();
+    /// let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+    /// let injection = TemporalInjection::gaussian(10.0, 2.0, 0.1);
+    ///
+    /// let model = LangmuirSingle::from_domain(
+    ///     &column, &mobile_phase,
+    ///     1.2, 0.4, 2.0,
+    ///     injection,
+    /// );
+    ///
+    /// assert_eq!(model.spatial_points(), 100);
+    /// assert!((model.column_length() - 0.25).abs() < 1e-12);
+    /// ```
+    pub fn from_domain(
+        column: &crate::domain::Column,
+        mobile_phase: &crate::domain::MobilePhase,
+        lambda: f64,
+        langmuir_k: f64,
+        port_number: f64,
+        injection: TemporalInjection,
+    ) -> Self {
+        Self::new(
+            lambda,
+            langmuir_k,
+            port_number,
+            column.porosity,
+            mobile_phase.velocity,
+            column.column_length,
+            column.n_points,
+            injection,
+        )
+    }
+
     /// Returns the temporal injection profile at the column inlet
     pub fn injection(&self) -> &TemporalInjection {
         &self.injection
@@ -954,5 +1012,51 @@ mod tests {
             ),
             "Absent metadata block must yield MissingKey"
         );
+    }
+
+    #[test]
+    fn test_from_domain_builds_equivalent_model() {
+        use crate::domain::{Column, MobilePhase};
+
+        let column = Column::new(0.25, 100, 0.4, None).unwrap();
+        let mobile_phase = MobilePhase::new(1e-4, None).unwrap();
+        let injection = TemporalInjection::gaussian(10.0, 2.0, 0.1);
+
+        let model = LangmuirSingle::from_domain(&column, &mobile_phase, 1.2, 0.4, 2.0, injection);
+
+        // Geometry matches column
+        assert!((model.column_length() - 0.25).abs() < 1e-12);
+        assert_eq!(model.spatial_points(), 100);
+
+        // Physics matches manual construction
+        let reference = LangmuirSingle::new(
+            1.2,
+            0.4,
+            2.0,
+            0.4,
+            1e-4,
+            0.25,
+            100,
+            TemporalInjection::gaussian(10.0, 2.0, 0.1),
+        );
+        assert!((model.column_length() - reference.column_length()).abs() < 1e-12);
+        assert_eq!(model.spatial_points(), reference.spatial_points());
+    }
+
+    #[test]
+    fn test_from_domain_propagates_column_validation() {
+        use crate::domain::{Column, MobilePhase};
+
+        // Column::new already validates — from_domain cannot receive invalid column
+        assert!(Column::new(0.0, 100, 0.4, None).is_err());
+        assert!(Column::new(0.25, 1, 0.4, None).is_err());
+        assert!(Column::new(0.25, 100, 1.5, None).is_err());
+
+        // Valid construction succeeds
+        let column = Column::new(0.25, 100, 0.4, None).unwrap();
+        let mp = MobilePhase::new(1e-4, None).unwrap();
+        let model =
+            LangmuirSingle::from_domain(&column, &mp, 1.2, 0.4, 2.0, TemporalInjection::none());
+        assert_eq!(model.spatial_points(), 100);
     }
 }

--- a/src/output/visualization/chromatogram.rs
+++ b/src/output/visualization/chromatogram.rs
@@ -886,7 +886,11 @@ mod tests {
             self.n_points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             let c = state
                 .get(PhysicalQuantity::Concentration)
                 .unwrap()
@@ -920,7 +924,11 @@ mod tests {
             self.n_points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             let m = state
                 .get(PhysicalQuantity::Concentration)
                 .unwrap()

--- a/src/output/visualization/steady.rs
+++ b/src/output/visualization/steady.rs
@@ -604,7 +604,11 @@ mod tests {
             self.n_points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             let c = state
                 .get(PhysicalQuantity::Concentration)
                 .unwrap()
@@ -641,7 +645,11 @@ mod tests {
             self.n_points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             let m = state
                 .get(PhysicalQuantity::Concentration)
                 .unwrap()

--- a/src/physics/context.rs
+++ b/src/physics/context.rs
@@ -1,0 +1,373 @@
+//! Typed compute context for physical model evaluation.
+//!
+//! This module defines [`ComputeContext`], the type passed by solvers to
+//! physical models at each time step. It replaces the previous mechanism
+//! that injected the current time via `state.set_metadata("time", t)`.
+//!
+//! # Design (DD-008)
+//!
+//! `ComputeContext` is structurally aligned with the oxiflow `ComputeContext`,
+//! without depending on it. Convergence is deferred to post-v1.0.0 (DD-014).
+//!
+//! The two infallible fields `time` and `time_step` are always available.
+//! Optional derived variables are stored in a typed
+//! `HashMap<ContextVariable, ContextValue>`.
+//!
+//! # Usage in solvers
+//!
+//! ```rust,no_run
+//! use chrom_rs::physics::ComputeContext;
+//!
+//! // Inside the solver integration loop:
+//! // let ctx = ComputeContext::new(t, dt);
+//! // let physics = model.compute_physics(&state, &ctx);
+//! ```
+//!
+//! # Usage in models
+//!
+//! ```rust,no_run
+//! use chrom_rs::physics::{ComputeContext, PhysicalState};
+//!
+//! // Inside PhysicalModel::compute_physics:
+//! // let t = ctx.time();
+//! // let c_inlet = self.injection.evaluate(t);
+//! ```
+
+use nalgebra::{DMatrix, DVector};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+// =============================================================================
+// ContextVariable
+// =============================================================================
+
+/// Typed key for [`ComputeContext`] variables.
+///
+/// Each variant identifies a category of derived physical quantity.
+/// `ContextVariable` implements `Hash + Eq` so it can be used as a
+/// `HashMap` key.
+///
+/// # Variants
+///
+/// | Variant | Usage |
+/// |---------|-------|
+/// | `Time` | Current time $t$ (infallible duplicate of `ctx.time()`) |
+/// | `TimeStep` | Time step $\Delta t$ (infallible duplicate of `ctx.time_step()`) |
+/// | `SpatialGradient` | Spatial gradient $\partial / \partial x_d$ of a component |
+/// | `External` | User-defined named variable |
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ContextVariable {
+    /// Current simulation time $t$ \[s\].
+    Time,
+
+    /// Current time step $\Delta t$ \[s\].
+    TimeStep,
+
+    /// Spatial gradient along axis `dimension` for species / component `component`.
+    SpatialGradient {
+        /// Index of the spatial dimension (0 = axial for 1-D models).
+        dimension: usize,
+        /// Component (species) index — `None` for a scalar field.
+        component: Option<usize>,
+    },
+
+    /// User-defined named variable.
+    External {
+        /// Variable name.
+        name: Cow<'static, str>,
+    },
+}
+
+// =============================================================================
+// ContextValue
+// =============================================================================
+
+/// Typed value stored in [`ComputeContext`].
+///
+/// Aligned with oxiflow variants to facilitate future convergence (DD-014).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ContextValue {
+    /// Scalar value.
+    Scalar(f64),
+
+    /// Boolean flag.
+    Boolean(bool),
+
+    /// Nodal scalar field — one value per spatial node.
+    ///
+    /// Un élément par nœud spatial $z_i$, $i = 0, \ldots, N_z - 1$.
+    ScalarField(DVector<f64>),
+
+    /// Nodal vector field — $N_z \times d$ matrix.
+    ///
+    /// Matrice $N_z \times d$ : une ligne par nœud, une colonne par dimension.
+    VectorField(DMatrix<f64>),
+}
+
+// =============================================================================
+// ComputeContext
+// =============================================================================
+
+/// Typed compute context passed to physical models at each time step.
+///
+/// Replaces implicit time injection via `state.set_metadata("time", t)` with
+/// an explicit, infallible contract. `time()` and `time_step()` are always
+/// available — no `unwrap` required in model implementations.
+///
+/// # Example
+///
+/// ```rust
+/// use chrom_rs::physics::ComputeContext;
+///
+/// let ctx = ComputeContext::new(10.0, 0.01);
+/// assert!((ctx.time() - 10.0).abs() < 1e-12);
+/// assert!((ctx.time_step() - 0.01).abs() < 1e-12);
+/// ```
+#[derive(Debug, Clone)]
+pub struct ComputeContext {
+    /// Current simulation time $t$ \[s\].
+    time: f64,
+
+    /// Current time step $\Delta t$ \[s\].
+    time_step: f64,
+
+    /// Optional derived variables.
+    ///
+    /// Variables dérivées optionnelles, indexées par [`ContextVariable`].
+    variables: HashMap<ContextVariable, ContextValue>,
+}
+
+impl ComputeContext {
+    // =========================================================================
+    // Constructors
+    // =========================================================================
+
+    /// Creates a minimal context carrying `time` and `time_step`.
+    ///
+    /// The optional variable map is empty. Use [`insert`](Self::insert) to
+    /// add derived quantities when needed.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::physics::ComputeContext;
+    ///
+    /// let ctx = ComputeContext::new(10.0, 0.01);
+    /// assert!((ctx.time() - 10.0).abs() < 1e-12);
+    /// assert!((ctx.time_step() - 0.01).abs() < 1e-12);
+    /// assert!(ctx.is_empty());
+    /// ```
+    pub fn new(time: f64, time_step: f64) -> Self {
+        Self {
+            time,
+            time_step,
+            variables: HashMap::new(),
+        }
+    }
+
+    // =========================================================================
+    // Infallible accessors
+    // =========================================================================
+
+    /// Current simulation time $t$ \[s\].
+    ///
+    /// Infallible — always available without `unwrap`.
+    #[inline]
+    pub fn time(&self) -> f64 {
+        self.time
+    }
+
+    /// Current time step $\Delta t$ \[s\].
+    ///
+    /// Infallible — always available without `unwrap`.
+    #[inline]
+    pub fn time_step(&self) -> f64 {
+        self.time_step
+    }
+
+    // =========================================================================
+    // Variable accessors
+    // =========================================================================
+
+    /// Inserts or replaces a variable in the context.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::physics::{ComputeContext, ContextVariable, ContextValue};
+    ///
+    /// let mut ctx = ComputeContext::new(0.0, 0.01);
+    /// ctx.insert(
+    ///     ContextVariable::External { name: "inlet_flow".into() },
+    ///     ContextValue::Scalar(1e-6),
+    /// );
+    /// ```
+    pub fn insert(&mut self, key: ContextVariable, value: ContextValue) {
+        self.variables.insert(key, value);
+    }
+
+    /// Returns a reference to the value for a key, if present.
+    pub fn get(&self, key: &ContextVariable) -> Option<&ContextValue> {
+        self.variables.get(key)
+    }
+
+    /// Returns the scalar value of an `External` key, if present and scalar.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use chrom_rs::physics::{ComputeContext, ContextVariable, ContextValue};
+    ///
+    /// let mut ctx = ComputeContext::new(0.0, 0.01);
+    /// ctx.insert(
+    ///     ContextVariable::External { name: "pressure".into() },
+    ///     ContextValue::Scalar(101325.0),
+    /// );
+    /// assert!((ctx.external_scalar("pressure").unwrap() - 101325.0).abs() < 1e-6);
+    /// ```
+    pub fn external_scalar(&self, name: &str) -> Option<f64> {
+        let key = ContextVariable::External {
+            name: Cow::Owned(name.to_string()),
+        };
+        match self.variables.get(&key) {
+            Some(ContextValue::Scalar(v)) => Some(*v),
+            _ => None,
+        }
+    }
+
+    /// Returns the scalar field for a spatial gradient variable, if present.
+    pub fn spatial_gradient(
+        &self,
+        dimension: usize,
+        component: Option<usize>,
+    ) -> Option<&DVector<f64>> {
+        let key = ContextVariable::SpatialGradient {
+            dimension,
+            component,
+        };
+        match self.variables.get(&key) {
+            Some(ContextValue::ScalarField(v)) => Some(v),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` if no optional variables are stored.
+    pub fn is_empty(&self) -> bool {
+        self.variables.is_empty()
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nalgebra::DVector;
+
+    #[test]
+    fn test_context_new() {
+        let ctx = ComputeContext::new(10.0, 0.01);
+        assert!((ctx.time() - 10.0).abs() < 1e-12);
+        assert!((ctx.time_step() - 0.01).abs() < 1e-12);
+        assert!(ctx.is_empty());
+    }
+
+    #[test]
+    fn test_context_insert_and_get_scalar() {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        ctx.insert(
+            ContextVariable::External {
+                name: "pressure".into(),
+            },
+            ContextValue::Scalar(101325.0),
+        );
+        assert!(!ctx.is_empty());
+        match ctx.get(&ContextVariable::External {
+            name: "pressure".into(),
+        }) {
+            Some(ContextValue::Scalar(v)) => assert!((v - 101325.0).abs() < 1e-6),
+            _ => panic!("Expected Scalar"),
+        }
+    }
+
+    #[test]
+    fn test_external_scalar_accessor() {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        ctx.insert(
+            ContextVariable::External {
+                name: "flow".into(),
+            },
+            ContextValue::Scalar(1e-6),
+        );
+        assert!((ctx.external_scalar("flow").unwrap() - 1e-6).abs() < 1e-18);
+        assert!(ctx.external_scalar("unknown").is_none());
+    }
+
+    #[test]
+    fn test_spatial_gradient_accessor() {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        let field = DVector::from_vec(vec![1.0, 2.0, 3.0]);
+        ctx.insert(
+            ContextVariable::SpatialGradient {
+                dimension: 0,
+                component: None,
+            },
+            ContextValue::ScalarField(field.clone()),
+        );
+        let retrieved = ctx.spatial_gradient(0, None).unwrap();
+        assert_eq!(retrieved, &field);
+        assert!(ctx.spatial_gradient(1, None).is_none());
+    }
+
+    #[test]
+    fn test_context_variable_hash_eq() {
+        let a = ContextVariable::External {
+            name: "pressure".into(),
+        };
+        let b = ContextVariable::External {
+            name: "pressure".into(),
+        };
+        let c = ContextVariable::External {
+            name: "flow".into(),
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+
+        // Usable as HashMap key
+        let mut map = HashMap::new();
+        map.insert(a.clone(), 1u32);
+        assert_eq!(map.get(&b), Some(&1u32));
+        assert_eq!(map.get(&c), None);
+    }
+
+    #[test]
+    fn test_context_variable_spatial_gradient_eq() {
+        let a = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: Some(1),
+        };
+        let b = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: Some(1),
+        };
+        let c = ContextVariable::SpatialGradient {
+            dimension: 0,
+            component: None,
+        };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn test_context_value_boolean() {
+        let mut ctx = ComputeContext::new(0.0, 0.01);
+        ctx.insert(ContextVariable::Time, ContextValue::Boolean(true));
+        match ctx.get(&ContextVariable::Time) {
+            Some(ContextValue::Boolean(v)) => assert!(*v),
+            _ => panic!("Expected Boolean"),
+        }
+    }
+}

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -31,7 +31,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(nalgebra::DVector::from_vec(vec![1.0])))
 //! #     }
@@ -45,7 +45,8 @@
 //! let initial_state = model.setup_initial_state();
 //!
 //! // Compute physics at current state
-//! let physics_result = model.compute_physics(&initial_state);
+//! # let ctx = chrom_rs::physics::ComputeContext::new(0.0, 0.01);
+//! let physics_result = model.compute_physics(&initial_state, &ctx);
 //! # }
 //! ```
 //!
@@ -69,7 +70,7 @@
 //!         1
 //!     }
 //!
-//!     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+//!     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState {
 //!         // Compute and return the physics equations
 //!         state.clone()
 //!     }
@@ -93,13 +94,15 @@
 //! - **Langmuir 1D**: 1D chromatography with modified Langmuir isotherm
 
 // module declaration
+/// Typed compute context: [`ComputeContext`], [`ContextVariable`], [`ContextValue`].
+pub mod context;
 /// Core data types: [`PhysicalData`], [`PhysicalState`], and [`PhysicalQuantity`].
 pub mod data;
 /// Core traits: [`PhysicalModel`] and [`Exportable`].
 pub mod traits;
-// Model implementation
 
 // re-export commonly used types for convenience
+pub use context::{ComputeContext, ContextValue, ContextVariable};
 pub use data::PhysicalData;
 pub use traits::{
     ExportError, Exportable, PhysicalModel, PhysicalQuantity, PhysicalState, outlet_data,

--- a/src/physics/traits.rs
+++ b/src/physics/traits.rs
@@ -532,7 +532,7 @@ impl std::ops::Mul<f64> for PhysicalState {
 ///         self.points
 ///     }
 ///
-///     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+///     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState {
 ///         // Compute transport: dc/dt = -v * dc/dx
 ///         // (simplified - actual implementation would use finite differences)
 ///         let mut result = PhysicalState::empty();
@@ -567,7 +567,7 @@ pub trait PhysicalModel: Send + Sync {
     /// # #[typetag::serde]
     /// # impl PhysicalModel for MyModel {
     /// #   fn points(&self) -> usize { self.points }
-    /// #   fn compute_physics(&self, state: &chrom_rs::physics::PhysicalState) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
+    /// #   fn compute_physics(&self, state: &chrom_rs::physics::PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
     /// #   fn setup_initial_state(&self) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
     /// #   fn name(&self) -> &str { "MyModel" }
     /// # }
@@ -579,15 +579,19 @@ pub trait PhysicalModel: Send + Sync {
     /// Compute the physics at a given state
     ///
     /// # Arguments
-    /// * `state` - Current physical state of the system
+    ///
+    /// * `state` — Current physical state of the system
+    /// * `ctx`   — Compute context carrying the current time $t$ and time step
+    ///   $\Delta t$ (infallible), plus optional derived variables
     ///
     /// # Returns
-    /// Result of evaluating the physics (interpretation depends on model type)
+    ///
+    /// Result of evaluating the physics (interpretation depends on model type).
     ///
     /// # Physical Interpretation
     ///
     /// **For time-dependent models (ODE)**:
-    /// - Returns right-hand side f(y) of dy/dt = f(y)
+    /// - Returns right-hand side f(y) of dy/dt = f(y, t)
     /// - Solver integrates this over time using Euler, RK4, etc.
     /// - Example: chromatography transport-dispersion-adsorption
     ///
@@ -606,7 +610,19 @@ pub trait PhysicalModel: Send + Sync {
     /// - Isotherms, kinetics, reactions
     /// - Spatial derivatives (finite differences)
     /// - Boundary conditions
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState;
+    ///
+    /// # Breaking change (v0.3.0)
+    ///
+    /// The `ctx: &ComputeContext` argument replaces the previous convention of
+    /// injecting time via `state.set_metadata("time", t)`. Models now read
+    /// `ctx.time()` directly — infallible, no `unwrap_or` required.
+    ///
+    /// See [DD-008](https://github.com/biface/chromatography/issues/13).
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        ctx: &crate::physics::context::ComputeContext,
+    ) -> PhysicalState;
 
     /// Create the initial state for this physical model
     ///
@@ -647,7 +663,7 @@ pub trait PhysicalModel: Send + Sync {
     ///         state
     ///     }
     ///
-    ///     fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+    ///     fn compute_physics(&self, _state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState {
     ///         PhysicalState::empty()
     ///     }
     ///
@@ -667,7 +683,7 @@ pub trait PhysicalModel: Send + Sync {
     /// # #[typetag::serde]
     /// # impl PhysicalModel for Transport {
     /// #   fn points(&self) -> usize { 100 }
-    /// #   fn compute_physics(&self, _: &chrom_rs::physics::PhysicalState) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
+    /// #   fn compute_physics(&self, _: &chrom_rs::physics::PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
     /// #   fn setup_initial_state(&self) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
     /// fn name(&self) -> &str {
     ///     "Transport-Dispersion-Adsorption Model"
@@ -690,7 +706,7 @@ pub trait PhysicalModel: Send + Sync {
     /// # #[typetag::serde]
     /// # impl PhysicalModel for MyModel {
     /// #   fn points(&self) -> usize { 100 }
-    /// #   fn compute_physics(&self, _: &chrom_rs::physics::PhysicalState) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
+    /// #   fn compute_physics(&self, _: &chrom_rs::physics::PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
     /// #   fn setup_initial_state(&self) -> chrom_rs::physics::PhysicalState { chrom_rs::physics::PhysicalState::empty() }
     /// #   fn name(&self) -> &str { "MyModel" }
     /// fn description(&self) -> Option<&str> {

--- a/src/solver/methods/euler.rs
+++ b/src/solver/methods/euler.rs
@@ -56,7 +56,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 //! #     }
@@ -127,7 +127,7 @@ use crate::solver::{Scenario, SimulationResult, Solver, SolverConfiguration, Sol
 /// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
-/// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+/// #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 /// #     fn setup_initial_state(&self) -> PhysicalState {
 /// #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 /// #     }
@@ -230,14 +230,13 @@ impl Solver for EulerSolver {
 
             // ====== Euler step ======
 
-            // 0. Add metadata time to be used by injection condition
+            // 1. Build compute context for this time step (DD-008)
+            let ctx = crate::physics::ComputeContext::new(t, dt);
 
-            state.set_metadata("time".to_string(), t);
-
-            // 1. Compute physics: f(y_n, t_n)
+            // 2. Compute physics: f(y_n, t_n)
             //    This returns the right-hand side of dy/dt = f(y, t)
             //    For chromatography: transport + dispersion + adsorption terms
-            let physics: PhysicalState = scenario.model.compute_physics(&state);
+            let physics: PhysicalState = scenario.model.compute_physics(&state, &ctx);
 
             // 2. Update state: y_{n+1} = y_n + dt * f(y_n)
             //    PhysicalState implements Add and Mul<f64>, so this works naturally
@@ -323,7 +322,11 @@ mod tests {
             self.points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             // dy/dt = -k * y
             // return -k * y as the physics
 
@@ -363,7 +366,11 @@ mod tests {
             self.points
         }
 
-        fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            _state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             PhysicalState::new(
                 PhysicalQuantity::Concentration,
                 PhysicalData::uniform_vector(self.points, self.growth_rate),
@@ -761,7 +768,11 @@ mod tests {
                 self.points
             }
 
-            fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+            fn compute_physics(
+                &self,
+                _state: &PhysicalState,
+                _ctx: &crate::physics::ComputeContext,
+            ) -> PhysicalState {
                 // Return NaN to trigger validation error
                 PhysicalState::new(
                     PhysicalQuantity::Concentration,
@@ -810,7 +821,11 @@ mod tests {
                 self.points
             }
 
-            fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+            fn compute_physics(
+                &self,
+                _state: &PhysicalState,
+                _ctx: &crate::physics::ComputeContext,
+            ) -> PhysicalState {
                 // Return Inf to trigger validation error
                 PhysicalState::new(
                     PhysicalQuantity::Concentration,
@@ -892,7 +907,11 @@ mod tests {
                 self.points
             }
 
-            fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+            fn compute_physics(
+                &self,
+                _state: &PhysicalState,
+                _ctx: &crate::physics::ComputeContext,
+            ) -> PhysicalState {
                 let mut result = PhysicalState::empty();
 
                 result.set(

--- a/src/solver/methods/mod.rs
+++ b/src/solver/methods/mod.rs
@@ -55,7 +55,7 @@
 //! #[typetag::serde]
 //! impl PhysicalModel for MyModel {
 //!      fn points(&self) -> usize { 1 }
-//!      fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//!      fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //!      fn setup_initial_state(&self) -> PhysicalState {
 //!          PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 //!      }

--- a/src/solver/methods/rk4.rs
+++ b/src/solver/methods/rk4.rs
@@ -77,7 +77,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 //! #     }
@@ -159,7 +159,7 @@ use crate::solver::{
 /// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
-/// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+/// #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 /// #     fn setup_initial_state(&self) -> PhysicalState {
 /// #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 /// #     }
@@ -268,30 +268,31 @@ impl Solver for RK4Solver {
 
             // ====== RK4 Stages ======
 
-            state.set_metadata("time".to_string(), t);
+            // Build compute context for this time step (DD-008)
+            let ctx = crate::physics::ComputeContext::new(t, dt);
 
             // Stage 1: Slope at beginning of interval
             // k₁ = f(yₙ, tₙ)
 
-            let k1 = scenario.model.compute_physics(&state);
+            let k1 = scenario.model.compute_physics(&state, &ctx);
 
             // Stage 2: Slope at midpoint using Euler prediction with k₁
             // k₂ = f(yₙ + dt/2·k₁, tₙ + dt/2)
 
             let state_k2 = state.clone() + k1.clone() * (dt / 2.0);
-            let k2 = scenario.model.compute_physics(&state_k2);
+            let k2 = scenario.model.compute_physics(&state_k2, &ctx);
 
             // Stage 3: Slope at midpoint using Euler prediction with k₂
             // k₃ = f(yₙ + dt/2·k₂, tₙ + dt/2)
 
             let state_k3 = state.clone() + k2.clone() * (dt / 2.0);
-            let k3 = scenario.model.compute_physics(&state_k3);
+            let k3 = scenario.model.compute_physics(&state_k3, &ctx);
 
             // Stage 4: Slope at end using Euler prediction with k₃
             // k₄ = f(yₙ + dt·k₃, tₙ + dt)
 
             let state_k4 = state.clone() + k3.clone() * dt;
-            let k4 = scenario.model.compute_physics(&state_k4);
+            let k4 = scenario.model.compute_physics(&state_k4, &ctx);
 
             // ====== RK4 Update ======
 
@@ -383,7 +384,11 @@ mod tests {
             self.points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             // dy/dt = -k * y
             // return -k * y as the physics
 
@@ -423,7 +428,11 @@ mod tests {
             self.points
         }
 
-        fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            _state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             PhysicalState::new(
                 PhysicalQuantity::Concentration,
                 PhysicalData::uniform_vector(self.points, self.growth_rate),
@@ -460,7 +469,11 @@ mod tests {
             self.points
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             let mut result = PhysicalState::empty();
 
             // Get position and velocity
@@ -847,7 +860,11 @@ mod tests {
                 self.points
             }
 
-            fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+            fn compute_physics(
+                &self,
+                _state: &PhysicalState,
+                _ctx: &crate::physics::ComputeContext,
+            ) -> PhysicalState {
                 PhysicalState::new(
                     PhysicalQuantity::Concentration,
                     PhysicalData::uniform_vector(self.points, f64::NAN),
@@ -893,7 +910,11 @@ mod tests {
                 self.points
             }
 
-            fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+            fn compute_physics(
+                &self,
+                _state: &PhysicalState,
+                _ctx: &crate::physics::ComputeContext,
+            ) -> PhysicalState {
                 PhysicalState::new(
                     PhysicalQuantity::Concentration,
                     PhysicalData::uniform_vector(self.points, f64::INFINITY),
@@ -969,7 +990,11 @@ mod tests {
                 self.points
             }
 
-            fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+            fn compute_physics(
+                &self,
+                _state: &PhysicalState,
+                _ctx: &crate::physics::ComputeContext,
+            ) -> PhysicalState {
                 let mut result = PhysicalState::empty();
 
                 // dC/dt = 1

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -63,7 +63,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(nalgebra::DVector::from_vec(vec![1.0])))
 //! #     }
@@ -171,7 +171,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(nalgebra::DVector::from_vec(vec![1.0])))
 //! #     }
@@ -319,7 +319,7 @@
 //! # #[typetag::serde]
 //! # impl PhysicalModel for MyModel {
 //! #     fn points(&self) -> usize { 1 }
-//! #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+//! #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 //! #     fn setup_initial_state(&self) -> PhysicalState {
 //! #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(nalgebra::DVector::from_vec(vec![1.0])))
 //! #     }

--- a/src/solver/scenario.rs
+++ b/src/solver/scenario.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 /// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
-/// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+/// #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 /// #     fn setup_initial_state(&self) -> PhysicalState {
 /// #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 /// #     }
@@ -133,7 +133,11 @@ mod tests {
             10
         }
 
-        fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+        fn compute_physics(
+            &self,
+            state: &PhysicalState,
+            _ctx: &crate::physics::ComputeContext,
+        ) -> PhysicalState {
             if !self.content.is_empty() {
                 self.content.last().unwrap().clone() + state.clone()
             } else {

--- a/src/solver/traits.rs
+++ b/src/solver/traits.rs
@@ -584,7 +584,7 @@ impl SimulationResult {
 /// # #[typetag::serde]
 /// # impl PhysicalModel for MyModel {
 /// #     fn points(&self) -> usize { 1 }
-/// #     fn compute_physics(&self, state: &PhysicalState) -> PhysicalState { state.clone() }
+/// #     fn compute_physics(&self, state: &PhysicalState, _ctx: &chrom_rs::physics::ComputeContext) -> PhysicalState { state.clone() }
 /// #     fn setup_initial_state(&self) -> PhysicalState {
 /// #         PhysicalState::new(PhysicalQuantity::Concentration, PhysicalData::Vector(DVector::from_vec(vec![1.0])))
 /// #     }

--- a/tests/common/mock_models.rs
+++ b/tests/common/mock_models.rs
@@ -38,7 +38,11 @@ impl PhysicalModel for ExponentialDecay {
         self.points
     }
 
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        _ctx: &chrom_rs::physics::ComputeContext,
+    ) -> PhysicalState {
         // dy/dt = -k * y
         let mut result = state.clone();
 
@@ -96,7 +100,11 @@ impl PhysicalModel for ConstantGrowth {
         self.points
     }
 
-    fn compute_physics(&self, _state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        _state: &PhysicalState,
+        _ctx: &chrom_rs::physics::ComputeContext,
+    ) -> PhysicalState {
         // dy/dt = c (constant)
         PhysicalState::new(
             PhysicalQuantity::Concentration,
@@ -142,7 +150,11 @@ impl PhysicalModel for LinearTransport {
         self.points
     }
 
-    fn compute_physics(&self, state: &PhysicalState) -> PhysicalState {
+    fn compute_physics(
+        &self,
+        state: &PhysicalState,
+        _ctx: &chrom_rs::physics::ComputeContext,
+    ) -> PhysicalState {
         // Placeholder: just decay for now
         let mut result = state.clone();
 


### PR DESCRIPTION
## Summary

This PR delivers the `v0.3.0 · Domain & Context` milestone, introducing two
foundational layers that were missing from the v0.2.0 architecture:

1. **`domain/`** — a validated construction facade for physical equipment
2. **`ComputeContext`** — a typed compute context replacing implicit time injection

---

## Changes

### Refactor — field name alignment (step 0)

Renamed `LangmuirSingle` fields and JSON keys to match `LangmuirMulti` and
`output/` conventions:

- `length` → `column_length`
- `nz` → `n_points`

Propagated to: `benches/`, `examples/config/tfa/`, `src/cli/app.rs`,
`src/config/model.rs`, `src/models/langmuir_multi.rs` (JSON keys only).

> **Breaking**: JSON import/export keys changed — covered by the 0.2 → 0.3 semver bump.

---

### Feature — `src/domain/` (DD-011, closes #38)

New public module exposing validated, model-agnostic physical equipment types:

| Type | Fields | Derived accessors |
|------|--------|------------------|
| `Column` | `column_length`, `n_points`, `porosity`, `diameter?` | `dz()`, `phase_ratio()` |
| `MobilePhase` | `velocity`, `viscosity?` | `interstitial_velocity(porosity)` |
| `Sample` | `injections: HashMap<Option<String>, TemporalInjection>` | `as_map()` |
| `Detector` | `position: DetectorPosition` | `absolute_position()`, `node_index()`, `validate_against_column()` |

`DetectorPosition` supports `Outlet`, `Relative(f64)`, `Absolute(f64)`.

All types derive `Serialize + Deserialize`. Validated constructors return
`Result<T, XxxError>`. Bilingual rustdoc throughout (EN doc, FR/EN inline).

`LangmuirSingle` and `LangmuirMulti` gain `from_domain(column, mobile_phase, …)`
constructors delegating to `new()` — no internal ownership change.

---

### Feature — `ComputeContext` (DD-008, closes #47)

New `physics/context.rs` module with three types:

- `ComputeContext` — carries `time: f64` and `time_step: f64` as infallible
  fields, plus `HashMap<ContextVariable, ContextValue>` for optional derived quantities
- `ContextVariable` — typed enum key (`Hash + Eq`): `Time`, `TimeStep`,
  `SpatialGradient`, `External`
- `ContextValue` — typed value enum: `Scalar`, `Boolean`, `ScalarField`, `VectorField`

> **Breaking**: `PhysicalModel::compute_physics` signature updated:
>
> ```rust
> // v0.2.0 (removed)
> fn compute_physics(&self, state: &PhysicalState) -> PhysicalState;
>
> // v0.3.0
> fn compute_physics(&self, state: &PhysicalState, ctx: &ComputeContext) -> PhysicalState;
> ```

Solvers (Euler, RK4) now build `ComputeContext::new(t, dt)` at each step.
Models read `ctx.time()` directly — no more `state.set_metadata("time", t)`.

All implementors migrated: `src/`, `examples/`, `tests/`, `benches/`.
All doctests updated (`crate::` → `chrom_rs::` in doc examples).

---

### Docs — rustdoc fixes

- `domain/mod.rs`: intra-doc links resolved with full `crate::domain::*` paths
- `domain/sample.rs`: `PhysicalModel::set_injections` link resolved
- `cargo doc --no-deps` now generates **0 warnings**

---

## Issues closed

| Issue | Title |
|-------|-------|
| #38 | [FEAT] Implement domain/ module |
| #39 | [FEAT] Migrate ComputeContext to type-safe API |
| #41 | [TEST] Coverage audit — domain/ and ComputeContext ≥ 80% |
| #13 | [DD-008] Migration ComputeContext to type-safe API |
| #16 | [DD-011] Domain model — Column, MobilePhase, Sample, Detector |

## Coverage (2026-05-31)

All new modules satisfy the ≥ 80% criterion:

| Module | Function | Line | Region |
|--------|----------|------|--------|
| `domain/column.rs` | 92% | 89% | 83% |
| `domain/detector.rs` | 96% | 90% | 90% |
| `domain/phases.rs` | 89% | 87% | 86% |
| `domain/sample.rs` | 100% | 100% | 100% |
| `physics/context.rs` | 100% | 98% | 99% |

## Validation

- `cargo build` ✅
- `cargo fmt` ✅
- `cargo test` ✅ (494 unit + 13 doc + 8 integration + 5 convergence tests)
- `cargo clippy -- -D warnings` ✅
- `cargo bench` ✅
- `cargo doc --no-deps` ✅ (0 warnings)
- All examples pass ✅